### PR TITLE
feat: VC Docker Image

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,15 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-GO_CMD ?= go
+VC_REST_PATH=cmd/vc-rest
+
+# Namespace for the agent images
+DOCKER_OUTPUT_NS   ?= docker.pkg.github.com
+VC_REST_IMAGE_NAME   ?= trustbloc/edge-service/vc-rest
+
+# Tool commands (overridable)
+ALPINE_VER ?= 3.10
+GO_VER ?= 1.13.1
 
 .PHONY: all
 all: checks unit-test
@@ -17,6 +25,19 @@ lint:
 .PHONY: license
 license:
 	@scripts/check_license.sh
+
+.PHONY: vc-rest
+vc-rest:
+	@echo "Building vc-rest"
+	@mkdir -p ./build/bin
+	@cd ${VC_REST_PATH} && go build -o ../../build/bin/vc-rest main.go
+
+.PHONY: vc-rest-docker
+vc-rest-docker:
+	@echo "Building vc rest docker image"
+	@docker build -f ./images/vc-rest/Dockerfile --no-cache -t $(DOCKER_OUTPUT_NS)/$(VC_REST_IMAGE_NAME):latest \
+	--build-arg GO_VER=$(GO_VER) \
+	--build-arg ALPINE_VER=$(ALPINE_VER) .
 
 unit-test:
 	@scripts/check_unit.sh

--- a/ci/azure-pipelines.yml
+++ b/ci/azure-pipelines.yml
@@ -30,3 +30,28 @@ jobs:
         displayName: Run unit test
       - script: bash <(curl https://codecov.io/bash)
         displayName: Upload coverage to Codecov
+
+  - job: Publish
+    dependsOn:
+      - Checks
+      - UnitTest
+    condition: and(succeeded(), ne(variables['Build.Reason'], 'PullRequest'))
+    pool:
+      vmImage: ubuntu-18.04
+    timeoutInMinutes: 30
+    steps:
+      - template: azp-dependencies.yml
+      - checkout: self
+      - bash: |
+          function logout {
+            docker logout
+          }
+          trap logout EXIT
+          source ci/version_var.sh
+          echo $DOCKER_PASSWORD | docker login docker.pkg.github.com --username $DOCKER_USER --password-stdin
+          make vc-rest-docker
+          docker tag docker.pkg.github.com/trustbloc/edge-service/vc-rest:latest docker.pkg.github.com/trustbloc/edge-service/vc-rest:$VC_REST_TAG
+          docker push docker.pkg.github.com/trustbloc/edge-service/vc-rest:$VC_REST_TAG
+        env:
+          DOCKER_USER: $(DOCKER_USER)
+          DOCKER_PASSWORD: $(DOCKER_PASSWORD)

--- a/ci/version_var.sh
+++ b/ci/version_var.sh
@@ -1,0 +1,21 @@
+
+#
+# Copyright SecureKey Technologies Inc. All Rights Reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+
+# Release Parameters
+BASE_VERSION=0.1.1
+IS_RELEASE=false
+
+if [ $IS_RELEASE == false ]
+then
+  EXTRA_VERSION=snapshot-$(git rev-parse --short=7 HEAD)
+  PROJECT_VERSION=$BASE_VERSION-$EXTRA_VERSION
+else
+  PROJECT_VERSION=$BASE_VERSION
+fi
+
+export VC_REST_TAG=$PROJECT_VERSION

--- a/cmd/vc-rest/go.mod
+++ b/cmd/vc-rest/go.mod
@@ -8,6 +8,7 @@ replace github.com/trustbloc/edge-service => ../..
 
 require (
 	github.com/gorilla/mux v1.7.3
+	github.com/sirupsen/logrus v1.4.2
 	github.com/spf13/cobra v0.0.5
 	github.com/stretchr/testify v1.4.0
 	github.com/trustbloc/edge-service v0.0.0

--- a/cmd/vc-rest/startcmd/start.go
+++ b/cmd/vc-rest/startcmd/start.go
@@ -11,6 +11,7 @@ import (
 	"net/http"
 
 	"github.com/gorilla/mux"
+	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 
 	"github.com/trustbloc/edge-service/pkg/restapi/vc/operation"
@@ -89,6 +90,7 @@ func startEdgeService(parameters *vcRestParameters) error {
 		router.HandleFunc(handler.Path(), handler.Handle()).Methods(handler.Method())
 	}
 
+	log.Infof("Starting vc rest server on host %s", parameters.hostURL)
 	err := parameters.srv.ListenAndServe(parameters.hostURL, router)
 
 	return err

--- a/images/vc-rest/Dockerfile
+++ b/images/vc-rest/Dockerfile
@@ -1,0 +1,28 @@
+#
+# Copyright SecureKey Technologies Inc. All Rights Reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+ARG GO_VER
+ARG ALPINE_VER
+
+FROM golang:${GO_VER}-alpine${ALPINE_VER} as golang
+RUN apk add --no-cache \
+	gcc \
+	musl-dev \
+	git \
+	libtool \
+	bash \
+	make;
+ADD . src/github.com/trustbloc/edge-service
+WORKDIR src/github.com/trustbloc/edge-service
+ENV EXECUTABLES go git
+
+FROM golang as edge-service
+RUN make vc-rest
+
+
+FROM alpine:${ALPINE_VER} as base
+COPY --from=edge-service /go/src/github.com/trustbloc/edge-service/build/bin/vc-rest /usr/local/bin
+ENTRYPOINT ["vc-rest"]

--- a/pkg/restapi/vc/controller.go
+++ b/pkg/restapi/vc/controller.go
@@ -4,7 +4,7 @@ Copyright SecureKey Technologies Inc. All Rights Reserved.
 SPDX-License-Identifier: Apache-2.0
 */
 
-package edv
+package vc
 
 import (
 	"github.com/trustbloc/edge-service/pkg/restapi/vc/operation"

--- a/pkg/restapi/vc/controller_test.go
+++ b/pkg/restapi/vc/controller_test.go
@@ -4,7 +4,7 @@ Copyright SecureKey Technologies Inc. All Rights Reserved.
 SPDX-License-Identifier: Apache-2.0
 */
 
-package edv
+package vc
 
 import (
 	"net/http"

--- a/pkg/restapi/vc/operation/operations.go
+++ b/pkg/restapi/vc/operation/operations.go
@@ -41,7 +41,7 @@ func New() *Operation {
 	return svc
 }
 
-// Operation defines handlers for EDV service
+// Operation defines handlers for VC service
 type Operation struct {
 	handlers []Handler
 }


### PR DESCRIPTION
closes #11 

A Docker image for a VC server can now be published.

Added a line of output to indicate the server is running.

Fixed an incorrectly named package.

Fixed an incorrect comment.

Signed-off-by: Derek Trider <Derek.Trider@securekey.com>