### PR TITLE
feat: Use base58 encoded 128-bit values for document IDs

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ module github.com/trustbloc/edge-service
 go 1.13
 
 require (
+	github.com/btcsuite/btcutil v0.0.0-20190425235716-9e5f4b9a998d
 	github.com/google/uuid v1.1.1
 	github.com/gorilla/mux v1.7.3
 	github.com/hyperledger/aries-framework-go v0.1.2-0.20200204225820-ac6563e7d7d0

--- a/test/bdd/fixtures/edv-rest/.env
+++ b/test/bdd/fixtures/edv-rest/.env
@@ -5,7 +5,7 @@
 #
 
 EDV_REST_IMAGE=docker.pkg.github.com/trustbloc/edv/edv-rest
-EDV_REST_IMAGE_TAG=0.1.1
+EDV_REST_IMAGE_TAG=0.1.2-snapshot-75d5b1e
 
 EDV_HOST=0.0.0.0
 EDV_PORT=8071

--- a/test/bdd/pkg/vc/vc_steps.go
+++ b/test/bdd/pkg/vc/vc_steps.go
@@ -82,7 +82,7 @@ func (e *Steps) createProfile(profileName string) error {
 	}
 
 	if resp.StatusCode != http.StatusCreated {
-		return fmt.Errorf("received status code %d resp body %s", resp.StatusCode, respBytes)
+		return expectedStatusCodeError(http.StatusCreated, resp.StatusCode)
 	}
 
 	profileResponse := operation.ProfileResponse{}
@@ -151,7 +151,7 @@ func (e *Steps) createCredential(profileName string) error {
 	}
 
 	if resp.StatusCode != http.StatusCreated {
-		return fmt.Errorf("received status code %d resp body %s", resp.StatusCode, respBytes)
+		return expectedStatusCodeError(http.StatusCreated, resp.StatusCode)
 	}
 
 	e.bddContext.CreatedCredential = respBytes
@@ -181,7 +181,7 @@ func (e *Steps) storeCredential(profileName string) error {
 	defer closeReadCloser(resp.Body)
 
 	if resp.StatusCode != http.StatusOK {
-		return fmt.Errorf("received status code %d", resp.StatusCode)
+		return expectedStatusCodeError(http.StatusOK, resp.StatusCode)
 	}
 
 	return nil
@@ -222,7 +222,7 @@ func (e *Steps) retrieveCredential(profileName string) error {
 	}
 
 	if resp.StatusCode != http.StatusOK {
-		return fmt.Errorf("received status code %d resp body %s", resp.StatusCode, respBytes)
+		return expectedStatusCodeError(http.StatusOK, resp.StatusCode)
 	}
 
 	unescapedResponse, err := strconv.Unquote(string(respBytes))
@@ -253,7 +253,7 @@ func (e *Steps) verifyCredential() error {
 	}
 
 	if resp.StatusCode != http.StatusOK {
-		return fmt.Errorf("received status code %d resp body %s", resp.StatusCode, respBytes)
+		return expectedStatusCodeError(http.StatusOK, resp.StatusCode)
 	}
 
 	verifiedResp := operation.VerifyCredentialResponse{}
@@ -380,6 +380,10 @@ func getVCMap(vcBytes []byte) (map[string]interface{}, error) {
 
 func expectedStringError(expected, actual string) error {
 	return fmt.Errorf("expected %s but got %s instead", expected, actual)
+}
+
+func expectedStatusCodeError(expected, actual int) error {
+	return fmt.Errorf("expected status code %d but got status code %d instead", expected, actual)
 }
 
 func closeReadCloser(respBody io.ReadCloser) {


### PR DESCRIPTION
closes #66

VC-service now encodes document IDs to conform with the new version of the EDV server.

Updated the BDD tests to use the latest EDV image.

Fixed some incorrect error messages in the BDD-tests.

Fixed a few places in the retrieve document handler where errors occurred and the function didn't return after writing the error response.

Signed-off-by: Derek Trider <Derek.Trider@securekey.com>