### PR TITLE
feat: Support JWS proof format

### DIFF
--- a/pkg/doc/vc/crypto/crypto.go
+++ b/pkg/doc/vc/crypto/crypto.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 
 	"github.com/btcsuite/btcutil/base58"
+
 	"github.com/hyperledger/aries-framework-go/pkg/doc/signature/ed25519signature2018"
 	"github.com/hyperledger/aries-framework-go/pkg/doc/verifiable"
 	"github.com/hyperledger/aries-framework-go/pkg/kms/legacykms"
@@ -103,7 +104,7 @@ func (c *Crypto) SignCredential(dataProfile *vcprofile.DataProfile, vc *verifiab
 
 	signingCtx := &verifiable.LinkedDataProofContext{
 		VerificationMethod:      dataProfile.Creator,
-		SignatureRepresentation: verifiable.SignatureProofValue,
+		SignatureRepresentation: dataProfile.SignatureRepresentation,
 		SignatureType:           dataProfile.SignatureType,
 		Suite: ed25519signature2018.New(
 			ed25519signature2018.WithSigner(s)),

--- a/pkg/doc/vc/crypto/crypto_test.go
+++ b/pkg/doc/vc/crypto/crypto_test.go
@@ -51,6 +51,45 @@ func TestCrypto_SignCredential(t *testing.T) {
 		require.Equal(t, 1, len(signedVC.Proofs))
 	})
 
+	t.Run("test signature representation - JWS", func(t *testing.T) {
+		_, privateKey, err := ed25519.GenerateKey(rand.Reader)
+		require.NoError(t, err)
+
+		c := New(nil, nil)
+
+		p := getTestProfile()
+		p.DIDPrivateKey = base58.Encode(privateKey)
+		p.SignatureRepresentation = verifiable.SignatureJWS
+
+		signedVC, err := c.SignCredential(
+			p, &verifiable.Credential{ID: "http://example.edu/credentials/1872"})
+		require.NoError(t, err)
+		require.Equal(t, 1, len(signedVC.Proofs))
+
+		jwsProof := signedVC.Proofs[0]
+		_, ok := jwsProof["jws"]
+		require.True(t, ok)
+	})
+
+	t.Run("test signature representation - ProofValue", func(t *testing.T) {
+		_, privateKey, err := ed25519.GenerateKey(rand.Reader)
+		require.NoError(t, err)
+
+		c := New(nil, nil)
+
+		p := getTestProfile()
+		p.DIDPrivateKey = base58.Encode(privateKey)
+		p.SignatureRepresentation = verifiable.SignatureProofValue
+
+		signedVC, err := c.SignCredential(
+			p, &verifiable.Credential{ID: "http://example.edu/credentials/1872"})
+		require.NoError(t, err)
+		require.Equal(t, 1, len(signedVC.Proofs))
+
+		_, ok := signedVC.Proofs[0]["proofValue"]
+		require.True(t, ok)
+	})
+
 	t.Run("test error from creator", func(t *testing.T) {
 		pubKey, _, err := ed25519.GenerateKey(rand.Reader)
 		require.NoError(t, err)

--- a/pkg/doc/vc/profile/profile.go
+++ b/pkg/doc/vc/profile/profile.go
@@ -10,6 +10,8 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/hyperledger/aries-framework-go/pkg/doc/verifiable"
+
 	"github.com/trustbloc/edge-core/pkg/storage"
 )
 
@@ -30,13 +32,14 @@ type Profile struct {
 
 // DataProfile struct for profile
 type DataProfile struct {
-	Name          string     `json:"name"`
-	DID           string     `json:"did"`
-	URI           string     `json:"uri"`
-	SignatureType string     `json:"signatureType"`
-	Creator       string     `json:"creator"`
-	Created       *time.Time `json:"created"`
-	DIDPrivateKey string     `json:"didPrivateKey"`
+	Name                    string                             `json:"name"`
+	DID                     string                             `json:"did"`
+	URI                     string                             `json:"uri"`
+	SignatureType           string                             `json:"signatureType"`
+	SignatureRepresentation verifiable.SignatureRepresentation `json:"signatureRepresentation"`
+	Creator                 string                             `json:"creator"`
+	Created                 *time.Time                         `json:"created"`
+	DIDPrivateKey           string                             `json:"didPrivateKey"`
 }
 
 // SaveProfile saves issuer profile to underlying store

--- a/pkg/doc/vc/profile/profile_test.go
+++ b/pkg/doc/vc/profile/profile_test.go
@@ -12,6 +12,8 @@ import (
 
 	"github.com/stretchr/testify/require"
 
+	"github.com/hyperledger/aries-framework-go/pkg/doc/verifiable"
+
 	mockstorage "github.com/trustbloc/edge-core/pkg/storage/mockstore"
 )
 
@@ -48,11 +50,13 @@ func TestCredentialRecord_GetProfile(t *testing.T) {
 
 		created := time.Now().UTC()
 		valueStored := &DataProfile{
-			Name:          "issuer",
-			URI:           "https://example.com/credentials",
-			Created:       &created,
-			DID:           "did",
-			DIDPrivateKey: "privateKey",
+			Name:                    "issuer",
+			URI:                     "https://example.com/credentials",
+			Created:                 &created,
+			DID:                     "did",
+			DIDPrivateKey:           "privateKey",
+			SignatureType:           "SignatureType",
+			SignatureRepresentation: verifiable.SignatureProofValue,
 		}
 
 		err := record.SaveProfile(valueStored)

--- a/pkg/restapi/vc/operation/models.go
+++ b/pkg/restapi/vc/operation/models.go
@@ -34,11 +34,12 @@ type StoreVCRequest struct {
 
 // ProfileRequest struct the input for creating profile
 type ProfileRequest struct {
-	Name          string `json:"name"`
-	URI           string `json:"uri"`
-	SignatureType string `json:"signatureType"`
-	DID           string `json:"did"`
-	DIDPrivateKey string `json:"didPrivateKey"`
+	Name                    string                             `json:"name"`
+	URI                     string                             `json:"uri"`
+	SignatureType           string                             `json:"signatureType"`
+	SignatureRepresentation verifiable.SignatureRepresentation `json:"signatureRepresentation"`
+	DID                     string                             `json:"did"`
+	DIDPrivateKey           string                             `json:"didPrivateKey"`
 }
 
 // VerifyCredentialResponse describes verify credential response

--- a/pkg/restapi/vc/operation/operations.go
+++ b/pkg/restapi/vc/operation/operations.go
@@ -633,13 +633,14 @@ func (o *Operation) createProfile(pr *ProfileRequest) (*vcprofile.DataProfile, e
 
 	created := time.Now().UTC()
 	profileResponse := &vcprofile.DataProfile{
-		Name:          pr.Name,
-		URI:           pr.URI,
-		Created:       &created,
-		DID:           didDoc.ID,
-		SignatureType: pr.SignatureType,
-		Creator:       publicKeyID,
-		DIDPrivateKey: pr.DIDPrivateKey,
+		Name:                    pr.Name,
+		URI:                     pr.URI,
+		Created:                 &created,
+		DID:                     didDoc.ID,
+		SignatureType:           pr.SignatureType,
+		SignatureRepresentation: pr.SignatureRepresentation,
+		Creator:                 publicKeyID,
+		DIDPrivateKey:           pr.DIDPrivateKey,
 	}
 
 	err = o.profileStore.SaveProfile(profileResponse)

--- a/test/bdd/features/vc_e2e_api.feature
+++ b/test/bdd/features/vc_e2e_api.feature
@@ -10,16 +10,17 @@ Feature: Using VC REST API
 
   @e2e
   Scenario Outline: Store, retrieve, and verify credential and presentation.
-    Given Profile "<profile>" is created with DID "<did>" and privateKey "<privateKey>"
+    Given Profile "<profile>" is created with DID "<did>", privateKey "<privateKey>" and signatureHolder "<signatureHolder>"
     And   We can retrieve profile "<profile>" with DID "<did>"
     And   New credential is created under "<profile>" profile
     And   That credential is stored under "<profile>" profile
     Then  We can retrieve credential under "<profile>" profile
     And   Now we verify that credential with verified flag is "true" and verified msg contains "success"
-    And   Now we verify that presentation with verified flag is "true" and verified msg contains "success"
+    And   Now we verify that "JWS" signed presentation with verified flag is "true" and verified msg contains "success"
+    And   Now we verify that "ProofValue" signed presentation with verified flag is "true" and verified msg contains "success"
     Then  Update created credential status "Revoked" and status reason "Disciplinary action"
     And   Now we verify that credential with verified flag is "false" and verified msg contains "Revoked"
     Examples:
-      | profile | did | privateKey |
-      | myprofile |   |            |
-      | myprofilewithdid | did:v1:test:nym:z6MkiJFtehU8FcTu6hAKiBEzzD5LfZHRR9wiiyJCgkbCZ6XN | 4Gn9Ttw6Lf3oFBFqJNNdLFMc4mUbbpCYLNSQFGAxaLBXiJ6DuZpJ8qsZGaHqwyBptxJMEB8nFiqHDZ419XHHxudY |
+      | profile | did | privateKey | signatureHolder |
+      | myprofile |   |            | ProofValue |
+      | myprofilewithdid | did:v1:test:nym:z6MkiJFtehU8FcTu6hAKiBEzzD5LfZHRR9wiiyJCgkbCZ6XN | 4Gn9Ttw6Lf3oFBFqJNNdLFMc4mUbbpCYLNSQFGAxaLBXiJ6DuZpJ8qsZGaHqwyBptxJMEB8nFiqHDZ419XHHxudY | JWS |

--- a/test/bdd/pkg/context/context.go
+++ b/test/bdd/pkg/context/context.go
@@ -14,6 +14,8 @@ import (
 	vdripkg "github.com/hyperledger/aries-framework-go/pkg/vdri"
 	"github.com/hyperledger/aries-framework-go/pkg/vdri/httpbinding"
 	"github.com/trustbloc/trustbloc-did-method/pkg/vdri/trustbloc"
+
+	"github.com/trustbloc/edge-service/pkg/doc/vc/profile"
 )
 
 // BDDContext is a global context shared between different test suites in bddtests
@@ -23,6 +25,7 @@ type BDDContext struct {
 	CreateCredentialRequestTemplate []byte
 	CreatedCredential               []byte
 	CreatedPresentation             []byte
+	CreatedProfile                  *profile.DataProfile
 	StoreVCRequest                  []byte
 	VDRI                            vdriapi.Registry
 }
@@ -39,7 +42,8 @@ func NewBDDContext() (*BDDContext, error) {
 		ProfileRequestTemplate: []byte(`{
 		"name": "ToBeChangedInStep",
 		"uri": "https://example.com/credentials",
-		"signatureType": "Ed25519Signature2018"}`),
+		"signatureType": "Ed25519Signature2018",
+		"signatureRepresentation": 1}`),
 		CreateCredentialRequestTemplate: []byte(`{
 			"@context": ["https://www.w3.org/2018/credentials/v1"],
 "type": [


### PR DESCRIPTION
When creating credentials, we should be able to sign using jws field in the Linked Data Signature.
Also, add test to check verifiable presentation when signed using either 'JWT' or 'ProofValue' signature holder.

Closes #100

Signed-off-by: Sandra Vrtikapa <sandra.vrtikapa@securekey.com>