### PR TITLE
feat: CredentialsVerification API

### DIFF
--- a/pkg/restapi/vc/controller_test.go
+++ b/pkg/restapi/vc/controller_test.go
@@ -94,7 +94,7 @@ func TestVerifierController_GetOperations(t *testing.T) {
 
 	ops := controller.GetOperations()
 
-	require.Equal(t, 3, len(ops))
+	require.Equal(t, 4, len(ops))
 
 	require.Equal(t, "/verify", ops[0].Path())
 	require.Equal(t, http.MethodPost, ops[0].Method())

--- a/pkg/restapi/vc/operation/models.go
+++ b/pkg/restapi/vc/operation/models.go
@@ -83,29 +83,29 @@ type GenerateKeyPairResponse struct {
 	PublicKey string `json:"publicKey,omitempty"`
 }
 
-// CredentialVerificationsRequest request for issuing credential.
-type CredentialVerificationsRequest struct {
+// CredentialsVerificationRequest request for verifying credential.
+type CredentialsVerificationRequest struct {
 	Credential json.RawMessage                 `json:"credential,omitempty"`
-	Opts       *CredentialVerificationsOptions `json:"options,omitempty"`
+	Opts       *CredentialsVerificationOptions `json:"options,omitempty"`
 }
 
-// CredentialVerificationsOptions options for credential verifications.
-type CredentialVerificationsOptions struct {
+// CredentialsVerificationOptions options for credential verifications.
+type CredentialsVerificationOptions struct {
 	Checks []string `json:"checks,omitempty"`
 }
 
-// CredentialVerificationsSuccessResponse resp when credential verification is success.
-type CredentialVerificationsSuccessResponse struct {
+// CredentialsVerificationSuccessResponse resp when credential verification is success.
+type CredentialsVerificationSuccessResponse struct {
 	Checks []string `json:"checks,omitempty"`
 }
 
-// CredentialVerificationsFailResponse resp when credential verification is failed.
-type CredentialVerificationsFailResponse struct {
-	Checks []CredentialVerificationsCheckResult `json:"checks,omitempty"`
+// CredentialsVerificationFailResponse resp when credential verification is failed.
+type CredentialsVerificationFailResponse struct {
+	Checks []CredentialsVerificationCheckResult `json:"checks,omitempty"`
 }
 
-// CredentialVerificationsCheckResult resp containing failure check details.
-type CredentialVerificationsCheckResult struct {
+// CredentialsVerificationCheckResult resp containing failure check details.
+type CredentialsVerificationCheckResult struct {
 	Check              string `json:"check,omitempty"`
 	Error              string `json:"error,omitempty"`
 	VerificationMethod string `json:"verificationMethod,omitempty"`

--- a/test/bdd/pkg/verifier/verifier_steps.go
+++ b/test/bdd/pkg/verifier/verifier_steps.go
@@ -22,7 +22,8 @@ import (
 )
 
 const (
-	verifierURL = "http://localhost:8069"
+	verifierHostURL = "http://localhost:8069"
+	verifierBaseURL = verifierHostURL + "/verifier"
 )
 
 // Steps is steps for VC BDD tests
@@ -37,16 +38,16 @@ func NewSteps(ctx *context.BDDContext) *Steps {
 
 // RegisterSteps registers agent steps
 func (e *Steps) RegisterSteps(s *godog.Suite) {
-	s.Step(`^Employer verifies the transcript provided by "([^"]*)"$`, e.credentialVerifications)
+	s.Step(`^Employer verifies the transcript provided by "([^"]*)"$`, e.credentialsVerification)
 }
 
-func (e *Steps) credentialVerifications(user string) error {
+func (e *Steps) credentialsVerification(user string) error {
 	vc := e.bddContext.Args[user]
 	checks := []string{"proof"}
 
-	req := &operation.CredentialVerificationsRequest{
+	req := &operation.CredentialsVerificationRequest{
 		Credential: []byte(vc),
-		Opts: &operation.CredentialVerificationsOptions{
+		Opts: &operation.CredentialsVerificationOptions{
 			Checks: checks,
 		},
 	}
@@ -56,7 +57,7 @@ func (e *Steps) credentialVerifications(user string) error {
 		return err
 	}
 
-	endpointURL := verifierURL + "/verifications"
+	endpointURL := verifierBaseURL + "/credentials"
 
 	resp, err := http.Post(endpointURL, "application/json", //nolint: bodyclose
 		bytes.NewBuffer(reqBytes))
@@ -77,7 +78,7 @@ func (e *Steps) credentialVerifications(user string) error {
 		return bddutil.ExpectedStatusCodeError(http.StatusOK, resp.StatusCode, respBytes)
 	}
 
-	verificationResp := operation.CredentialVerificationsSuccessResponse{}
+	verificationResp := operation.CredentialsVerificationSuccessResponse{}
 
 	err = json.Unmarshal(respBytes, &verificationResp)
 	if err != nil {


### PR DESCRIPTION
- Add new endpoint https://w3c-ccg.github.io/vc-verifier-http-api/#/internal/verifyCredential and point it to existing /verifications code
- Deprecate exising /verifications API
- Update BDD tests to use new endpoint

closes #149 

Signed-off-by: Rolson Quadras <rolson.quadras@securekey.com>