### PR TITLE
refactor: Issue Credential API - Use issuerDID as default signing DID when request Opts is empty

### DIFF
--- a/pkg/restapi/vc/operation/models.go
+++ b/pkg/restapi/vc/operation/models.go
@@ -53,8 +53,8 @@ type VerifyCredentialResponse struct {
 
 // IssueCredentialRequest request for issuing credential.
 type IssueCredentialRequest struct {
-	Credential json.RawMessage        `json:"credential,omitempty"`
-	Opts       IssueCredentialOptions `json:"options,omitempty"`
+	Credential json.RawMessage         `json:"credential,omitempty"`
+	Opts       *IssueCredentialOptions `json:"options,omitempty"`
 }
 
 // IssueCredentialOptions options for issuing credential.

--- a/pkg/restapi/vc/operation/operations.go
+++ b/pkg/restapi/vc/operation/operations.go
@@ -858,8 +858,14 @@ func (o *Operation) issueCredentialHandler(rw http.ResponseWriter, req *http.Req
 		return
 	}
 
+	// use issuer id if options doesn't specify the DID
+	signerDID := validatedCred.Issuer.ID
+	if cred.Opts != nil && cred.Opts.AssertionMethod != "" {
+		signerDID = cred.Opts.AssertionMethod
+	}
+
 	// sign the credential
-	signedVC, err := o.signCredential(validatedCred, cred.Opts.AssertionMethod, verifiable.SignatureJWS)
+	signedVC, err := o.signCredential(validatedCred, signerDID, verifiable.SignatureJWS)
 	if err != nil {
 		o.writeErrorResponse(rw, http.StatusInternalServerError, fmt.Sprintf("failed to sign credential:"+
 			" %s", err.Error()))

--- a/test/bdd/features/issuer_e2e_api.feature
+++ b/test/bdd/features/issuer_e2e_api.feature
@@ -11,12 +11,12 @@ Feature: Issuer VC REST API
   @issueCred_api
   Scenario: Issue Credential API
     Given "University" has a DID
-    Then  "University" application service verifies the credential created by Issuer Service issueCredential API with it's DID
+    Then  "University" application service verifies the credential created by Issuer Service - Issue Credential API with it's DID
 
   @composeAndIssueCred_api
   Scenario: Compose and Issue Credential API
     Given "University" has a DID
-    Then  "University" application service verifies the credential created by Issuer Service composeAndIssueCredential API with it's DID
+    Then  "University" application service verifies the credential created by Issuer Service - Compose And Issue Credential API with it's DID
 
   @createDID_issueCred_api
   Scenario: Issue Credential API with Create DID steps

--- a/test/bdd/pkg/issuer/issuer_steps.go
+++ b/test/bdd/pkg/issuer/issuer_steps.go
@@ -106,9 +106,9 @@ func (e *Steps) RegisterSteps(s *godog.Suite) {
 		e.createAndVerifyCredential)
 	s.Step(`^"([^"]*)" has stored her transcript from the University$`, e.createCredential)
 	s.Step(`^"([^"]*)" has a DID$`, e.generateDID)
-	s.Step(`^"([^"]*)" application service verifies the credential created by Issuer Service issueCredential API with it's DID$`, //nolint: lll
+	s.Step(`^"([^"]*)" application service verifies the credential created by Issuer Service - Issue Credential API with it's DID$`, //nolint: lll
 		e.issueCred)
-	s.Step(`^"([^"]*)" application service verifies the credential created by Issuer Service composeAndIssueCredential API with it's DID$`, //nolint: lll
+	s.Step(`^"([^"]*)" application service verifies the credential created by Issuer Service - Compose And Issue Credential API with it's DID$`, //nolint: lll
 		e.composeAndIssueCred)
 }
 
@@ -225,7 +225,7 @@ func (e *Steps) signCredential(did string) ([]byte, error) {
 
 	req := &operation.IssueCredentialRequest{
 		Credential: []byte(validVC),
-		Opts:       operation.IssueCredentialOptions{AssertionMethod: did},
+		Opts:       &operation.IssueCredentialOptions{AssertionMethod: did},
 	}
 
 	reqBytes, err := json.Marshal(req)


### PR DESCRIPTION
Signed-off-by: Rolson Quadras <rolson.quadras@securekey.com>