### PR TITLE
feat: interop tests with transmute VCs & VPs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,10 @@ VC_REST_PATH=cmd/vc-rest
 DOCKER_OUTPUT_NS   ?= docker.pkg.github.com
 VC_REST_IMAGE_NAME   ?= trustbloc/edge-service/vc-rest
 DID_ELEMENT_SIDETREE_REQUEST_URL ?= https://element-did.com/api/v1/sidetree/requests
+# LOCAL UNIVERSAL REGISTRAR ENDPOINT
+UNIVERSAL_REGISTRAR_LOCAL ?= http://localhost:9080
+# REMOTE UNIVERSAL REGISTRAR ENDPOINT
+UNIVERSAL_REGISTRAR_REMOTE ?= https://uniregistrar.io
 
 # Tool commands (overridable)
 ALPINE_VER ?= 3.10
@@ -68,7 +72,13 @@ create-element-did: clean
 uniregistrar-create-dids: clean
 	@mkdir -p .build
 	@cp scripts/uniregistrar-create-dids.js .build/
-	@scripts/uniregistrar_create_dids.sh
+	@UNIREGISTRAR_LOCAL=$(UNIVERSAL_REGISTRAR_LOCAL) UNIREGISTRAR_REMOTE=$(UNIVERSAL_REGISTRAR_REMOTE) scripts/uniregistrar_create_dids.sh
+
+# this target creates VCs and VPs from other systems for interop tests
+prepare-test-verifiables: clean
+	@mkdir -p .build
+	@cp scripts/prepare-test-verifiables.js .build/
+	@scripts/prepare_test_verifiables.sh
 
 .PHONY: clean
 clean: clean-build

--- a/cmd/vc-rest/go.mod
+++ b/cmd/vc-rest/go.mod
@@ -8,7 +8,7 @@ replace github.com/trustbloc/edge-service => ../..
 
 require (
 	github.com/gorilla/mux v1.7.4
-	github.com/hyperledger/aries-framework-go v0.1.3-0.20200328075212-b14f446f90bb
+	github.com/hyperledger/aries-framework-go v0.1.3-0.20200401225228-e17df7efdb4b
 	github.com/sirupsen/logrus v1.4.2
 	github.com/spf13/cobra v0.0.6
 	github.com/stretchr/testify v1.5.1

--- a/cmd/vc-rest/go.sum
+++ b/cmd/vc-rest/go.sum
@@ -127,6 +127,8 @@ github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpO
 github.com/hyperledger/aries-framework-go v0.1.3-0.20200325175154-d18ad2581ed9/go.mod h1:tycudP7ZuQK/kOBknpIfTkVaZt/JryfSneKQ0z8GDLc=
 github.com/hyperledger/aries-framework-go v0.1.3-0.20200328075212-b14f446f90bb h1:aT5ZKRVmrgAwfUUTlbHwQGfvJJaJhuTEePtZl66FWbM=
 github.com/hyperledger/aries-framework-go v0.1.3-0.20200328075212-b14f446f90bb/go.mod h1:ahfLvGFjR3kNGgj8xVSlaHcHHaiF6gRmF971rulr9Tg=
+github.com/hyperledger/aries-framework-go v0.1.3-0.20200401225228-e17df7efdb4b h1:OCnjgH0BGtlGt6ste6MfVWJx/lOniOc6A8sb3BuBHBM=
+github.com/hyperledger/aries-framework-go v0.1.3-0.20200401225228-e17df7efdb4b/go.mod h1:ahfLvGFjR3kNGgj8xVSlaHcHHaiF6gRmF971rulr9Tg=
 github.com/inconshreveable/mousetrap v1.0.0 h1:Z8tu5sraLXCXIcARxBp/8cbvlwVa7Z1NHg9XEKhtSvM=
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
 github.com/jessevdk/go-flags v0.0.0-20141203071132-1679536dcc89/go.mod h1:4FA24M0QyGHXBuZZK/XkWh8h0e1EYbRYJSGM75WSRxI=
@@ -255,10 +257,12 @@ github.com/trustbloc/edv v0.1.3-0.20200331230259-afb8871c7535/go.mod h1:sGaSCAXM
 github.com/trustbloc/sidetree-core-go v0.1.3-0.20200316172436-5d9ccb59942d h1:fcwBIhwy5j2dPkYtuercCkNDd0Vl3bmmixwOMRSMysk=
 github.com/trustbloc/sidetree-core-go v0.1.3-0.20200316172436-5d9ccb59942d/go.mod h1:qJ7oOPveEqrxTsO4KJsSHUM/Yivym221Dvd+IUq1V1U=
 github.com/trustbloc/sidetree-core-go v0.1.3-0.20200329202924-b30de8bf5c8a/go.mod h1:qJ7oOPveEqrxTsO4KJsSHUM/Yivym221Dvd+IUq1V1U=
+github.com/trustbloc/sidetree-core-go v0.1.3-0.20200331141546-1d1a08ef4a77 h1:WYVz7WkWqcqcTMEzHOm4u5NJmtefFAquamOneGHJvdI=
 github.com/trustbloc/sidetree-core-go v0.1.3-0.20200331141546-1d1a08ef4a77/go.mod h1:qJ7oOPveEqrxTsO4KJsSHUM/Yivym221Dvd+IUq1V1U=
 github.com/trustbloc/trustbloc-did-method v0.0.0-20200327220339-c2f631bbc668 h1:lURAaa/zfUtYzLZo1JQxH4NI9erhjS2v18Wr0HW33iM=
 github.com/trustbloc/trustbloc-did-method v0.0.0-20200327220339-c2f631bbc668/go.mod h1:m3dXqWCbp1gmeMshYOQv2Df5bDkutuEJNuvcBun1PqA=
 github.com/trustbloc/trustbloc-did-method v0.0.0-20200401180214-c51c8a66c762/go.mod h1:9+60uKTrwcac0mdCp+yyw5GyqxfSa1/el4NWF0h+iRw=
+github.com/trustbloc/trustbloc-did-method v0.0.0-20200401211047-51191c718d4a h1:C7sIPZGdgxHGSALEBqgJiLNJXK9/V3SEUevruR6EvcI=
 github.com/trustbloc/trustbloc-did-method v0.0.0-20200401211047-51191c718d4a/go.mod h1:+NGDJy6pHkLaYBosTpWQy8qto7rbdSs+NDG4TiF8ggk=
 github.com/ugorji/go v1.1.4/go.mod h1:uQMGLiO92mf5W77hV/PUCpI3pbzQx3CRekS0kk+RGrc=
 github.com/ugorji/go/codec v0.0.0-20181204163529-d75b2dcb6bc8/go.mod h1:VFNgLljTbGfSG7qAOspJ7OScBnGdDN/yBr0sguwnwf0=

--- a/cmd/vc-rest/startcmd/start.go
+++ b/cmd/vc-rest/startcmd/start.go
@@ -100,6 +100,7 @@ const (
 	didMethodVeres   = "v1"
 	didMethodElement = "elem"
 	didMethodSov     = "sov"
+	didMethodWeb     = "web"
 )
 
 // mode in which to run the vc-rest service
@@ -375,7 +376,7 @@ func supportedMode(mode string) bool {
 
 // acceptsDID returns if given did method is accepted by VC REST api
 func acceptsDID(method string) bool {
-	return method == didMethodVeres || method == didMethodElement || method == didMethodSov
+	return method == didMethodVeres || method == didMethodElement || method == didMethodSov || method == didMethodWeb
 }
 
 func createProvider(parameters *vcRestParameters) (storage.Provider, error) {

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/btcsuite/btcutil v1.0.1
 	github.com/google/uuid v1.1.1
 	github.com/gorilla/mux v1.7.4
-	github.com/hyperledger/aries-framework-go v0.1.3-0.20200328075212-b14f446f90bb
+	github.com/hyperledger/aries-framework-go v0.1.3-0.20200401225228-e17df7efdb4b
 	github.com/sirupsen/logrus v1.4.2
 	github.com/stretchr/testify v1.5.1
 	github.com/trustbloc/edge-core v0.1.3-0.20200318193133-ec6c4caf61ae

--- a/go.sum
+++ b/go.sum
@@ -96,6 +96,8 @@ github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpO
 github.com/hyperledger/aries-framework-go v0.1.3-0.20200325175154-d18ad2581ed9/go.mod h1:tycudP7ZuQK/kOBknpIfTkVaZt/JryfSneKQ0z8GDLc=
 github.com/hyperledger/aries-framework-go v0.1.3-0.20200328075212-b14f446f90bb h1:aT5ZKRVmrgAwfUUTlbHwQGfvJJaJhuTEePtZl66FWbM=
 github.com/hyperledger/aries-framework-go v0.1.3-0.20200328075212-b14f446f90bb/go.mod h1:ahfLvGFjR3kNGgj8xVSlaHcHHaiF6gRmF971rulr9Tg=
+github.com/hyperledger/aries-framework-go v0.1.3-0.20200401225228-e17df7efdb4b h1:OCnjgH0BGtlGt6ste6MfVWJx/lOniOc6A8sb3BuBHBM=
+github.com/hyperledger/aries-framework-go v0.1.3-0.20200401225228-e17df7efdb4b/go.mod h1:ahfLvGFjR3kNGgj8xVSlaHcHHaiF6gRmF971rulr9Tg=
 github.com/inconshreveable/mousetrap v1.0.0 h1:Z8tu5sraLXCXIcARxBp/8cbvlwVa7Z1NHg9XEKhtSvM=
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
 github.com/jessevdk/go-flags v0.0.0-20141203071132-1679536dcc89/go.mod h1:4FA24M0QyGHXBuZZK/XkWh8h0e1EYbRYJSGM75WSRxI=
@@ -191,10 +193,12 @@ github.com/trustbloc/edv v0.1.3-0.20200305035835-69c9f3cb077b/go.mod h1:sGaSCAXM
 github.com/trustbloc/sidetree-core-go v0.1.3-0.20200316172436-5d9ccb59942d h1:fcwBIhwy5j2dPkYtuercCkNDd0Vl3bmmixwOMRSMysk=
 github.com/trustbloc/sidetree-core-go v0.1.3-0.20200316172436-5d9ccb59942d/go.mod h1:qJ7oOPveEqrxTsO4KJsSHUM/Yivym221Dvd+IUq1V1U=
 github.com/trustbloc/sidetree-core-go v0.1.3-0.20200329202924-b30de8bf5c8a/go.mod h1:qJ7oOPveEqrxTsO4KJsSHUM/Yivym221Dvd+IUq1V1U=
+github.com/trustbloc/sidetree-core-go v0.1.3-0.20200331141546-1d1a08ef4a77 h1:WYVz7WkWqcqcTMEzHOm4u5NJmtefFAquamOneGHJvdI=
 github.com/trustbloc/sidetree-core-go v0.1.3-0.20200331141546-1d1a08ef4a77/go.mod h1:qJ7oOPveEqrxTsO4KJsSHUM/Yivym221Dvd+IUq1V1U=
 github.com/trustbloc/trustbloc-did-method v0.0.0-20200327220339-c2f631bbc668 h1:lURAaa/zfUtYzLZo1JQxH4NI9erhjS2v18Wr0HW33iM=
 github.com/trustbloc/trustbloc-did-method v0.0.0-20200327220339-c2f631bbc668/go.mod h1:m3dXqWCbp1gmeMshYOQv2Df5bDkutuEJNuvcBun1PqA=
 github.com/trustbloc/trustbloc-did-method v0.0.0-20200401180214-c51c8a66c762/go.mod h1:9+60uKTrwcac0mdCp+yyw5GyqxfSa1/el4NWF0h+iRw=
+github.com/trustbloc/trustbloc-did-method v0.0.0-20200401211047-51191c718d4a h1:C7sIPZGdgxHGSALEBqgJiLNJXK9/V3SEUevruR6EvcI=
 github.com/trustbloc/trustbloc-did-method v0.0.0-20200401211047-51191c718d4a/go.mod h1:+NGDJy6pHkLaYBosTpWQy8qto7rbdSs+NDG4TiF8ggk=
 github.com/ugorji/go/codec v0.0.0-20181204163529-d75b2dcb6bc8/go.mod h1:VFNgLljTbGfSG7qAOspJ7OScBnGdDN/yBr0sguwnwf0=
 github.com/xeipuuv/gojsonpointer v0.0.0-20180127040702-4e3ac2762d5f h1:J9EGpcZtP0E/raorCMxlFGSTBrsSlaDGf3jU/qvAE2c=

--- a/pkg/restapi/vc/operation/operations_test.go
+++ b/pkg/restapi/vc/operation/operations_test.go
@@ -933,7 +933,7 @@ func TestStoreVCHandler(t *testing.T) {
 		require.NoError(t, err)
 		rr := httptest.NewRecorder()
 		op.storeVCHandler(rr, req)
-		require.Equal(t, http.StatusBadRequest, rr.Code)
+		require.Equal(t, http.StatusInternalServerError, rr.Code)
 		require.Equal(t, rr.Body.String(), "key is nil")
 	})
 	t.Run("store vc err while creating the document - vault not found", func(t *testing.T) {
@@ -948,7 +948,7 @@ func TestStoreVCHandler(t *testing.T) {
 		require.NoError(t, err)
 		rr := httptest.NewRecorder()
 		op.storeVCHandler(rr, req)
-		require.Equal(t, http.StatusBadRequest, rr.Code)
+		require.Equal(t, http.StatusInternalServerError, rr.Code)
 		require.Equal(t, rr.Body.String(), errVaultNotFound.Error())
 	})
 	t.Run("store vc err missing profile name", func(t *testing.T) {
@@ -1074,8 +1074,8 @@ func TestRetrieveVCHandler(t *testing.T) {
 		rr := httptest.NewRecorder()
 
 		op.retrieveVCHandler(rr, req)
-		require.Equal(t, http.StatusBadRequest, rr.Code)
-		require.Equal(t, errDocumentNotFound.Error(), rr.Body.String())
+		require.Equal(t, http.StatusInternalServerError, rr.Code)
+		require.Contains(t, rr.Body.String(), errDocumentNotFound.Error())
 	})
 	t.Run("retrieve vc fail when writing document retrieval success", func(t *testing.T) {
 		client := edv.NewMockEDVClient("test", nil)
@@ -1184,8 +1184,8 @@ func TestRetrieveVCHandler(t *testing.T) {
 		rr := httptest.NewRecorder()
 
 		op.retrieveVCHandler(rr, r)
-		require.Equal(t, http.StatusBadRequest, rr.Code)
-		require.Equal(t, storage.ErrValueNotFound.Error(), rr.Body.String())
+		require.Equal(t, http.StatusInternalServerError, rr.Code)
+		require.Contains(t, rr.Body.String(), storage.ErrValueNotFound.Error())
 	})
 }
 

--- a/scripts/prepare-test-verifiables.js
+++ b/scripts/prepare-test-verifiables.js
@@ -1,0 +1,156 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+const axios = require('axios')
+const fs = require('fs')
+
+const bgGreen = "\x1b[32m"
+const reset = "\x1b[0m"
+
+// options based on various endpoints.
+const opts = {
+    providers: [
+        {
+            name: "transmute",
+            vc: {
+                path: "https://vc.transmute.world/credentials/issueCredential",
+                request: `{
+                "credential": %credential%
+                    }`,
+                replace: "%credential%"
+            },
+            vp: {
+                path: "https://vc.transmute.world/vc-data-model/presentations",
+                request: `{
+                  "presentation": %presentation% 
+                }`,
+                replace: "%presentation%"
+            }
+        }
+    ]
+}
+
+const presentationTemplate = {
+    "@context": [
+        "https://www.w3.org/2018/credentials/v1",
+        "https://www.w3.org/2018/credentials/examples/v1"
+    ],
+    type: "VerifiablePresentation",
+    verifiableCredential: {}
+}
+
+const axiosConfig = {
+    headers: {
+        'accept': 'application/json',
+        'Content-Type': 'application/json',
+    }
+};
+
+// createVerifiables creates verifiable credentials and veriable presentations.
+const createVerifiables = async (credential) => {
+    console.log(`Creating verifiable credentials and presentations from credential`)
+
+    var responses = []
+    const credentialStr = JSON.stringify(credential)
+    for (const provider of opts.providers) {
+        const response = {name: provider.name, output: []}
+        // create vc
+        if (provider.vc) {
+            console.log(`Creating verifiable credential for ${provider.name}, submitting request to ${provider.vc.path}`)
+
+            const rqst = provider.vc.request.replace(provider.vc.replace, credentialStr)
+            let resp
+            try {
+                resp = await axios.post(provider.vc.path, rqst, axiosConfig)
+            } catch (error) {
+                console.log(`Failed to create vc for ${provider.name}, cause ${error}`)
+                return
+            }
+
+            if (resp.status = 200) {
+                const output = `${process.env.OutputDir}${provider.name}_vc.json`
+                console.log(`Successfully created vc for ${provider.name}, writing to ${output}`)
+                writeToFile(output, resp.data)
+                response.output.push(output)
+                response.vc = resp.data
+            } else {
+                console.log(`Failed to create VC for ${provider.name} : ${resp.data}`)
+                continue
+            }
+        }
+
+        // create vp
+        if (provider.vp) {
+            console.log(`Creating verifiable presentation for ${provider.name}, submitting request to ${provider.vp.path}`)
+            const rqst = provider.vp.request.replace(provider.vp.replace, JSON.stringify(createPresentation(response.vc)))
+
+            let resp
+            try {
+                resp = await axios.post(provider.vp.path, rqst, axiosConfig)
+            } catch (error) {
+                console.log(`Failed to create VP for ${provider.name}, cause ${error}`, resp)
+                return
+            }
+
+            if (resp.status = 200) {
+                const output = `${process.env.OutputDir}${provider.name}_vp.json`
+                console.log(`Successfully created VP for ${provider.name}, writing to ${output}`)
+                writeToFile(output, resp.data)
+                response.output.push(output)
+            } else {
+                console.log(`Failed to create VP for ${provider.name} : ${resp.data}`)
+                continue
+            }
+        }
+
+        responses.push(response)
+    }
+
+    printResponseMessage(responses)
+}
+
+async function writeToFile(file, data) {
+    const content = JSON.stringify(data, null, '\t')
+    fs.writeFile(file, content, err => {
+        if (err) {
+            console.log('Error writing file :', err)
+        }
+    })
+}
+
+function createPresentation(vc) {
+    const p = Object.assign({}, presentationTemplate)
+    p.verifiableCredential = vc
+    return p
+}
+
+function printResponseMessage(responses) {
+    console.log(bgGreen)
+    responses.forEach((response, index) => {
+        console.log(`Successfully created verifiables for ${response.name}`)
+        console.log("Generated below files: ")
+        response.output.forEach((file, index) => {
+            console.log(bgGreen, `\t${file}`)
+        })
+    })
+    console.log(reset)
+}
+
+if (!process.env.OutputDir) {
+    console.log("Please provide output directory")
+    return
+}
+
+if (!process.env.CredentialPath) {
+    console.log("Please provide input credential")
+    return
+}
+
+const credential = require(`${process.env.CredentialPath}`)
+
+// create verifiable credentials and verifiable presentations.
+createVerifiables(credential)
+

--- a/scripts/prepare_test_verifiables.sh
+++ b/scripts/prepare_test_verifiables.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+#
+# Copyright SecureKey Technologies Inc. All Rights Reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+set -e
+
+echo "Running $0"
+
+ROOT=`pwd`
+OUTPUT_DIR=$ROOT/test/bdd/testdata/
+INPUT_CREDENTIAL=$ROOT/test/bdd/testdata/university_degree_credential.json
+
+echo "creating VCs for bddtests testdata"
+cd $ROOT/.build
+npm install axios
+OutputDir=${OUTPUT_DIR} CredentialPath=${INPUT_CREDENTIAL} node ./prepare-test-verifiables.js

--- a/scripts/uniregistrar-create-dids.js
+++ b/scripts/uniregistrar-create-dids.js
@@ -20,7 +20,7 @@ const driverOpts = {
         options: {"options":{"network":"danube"}},
         // send request to '' because of issue in local universal registrar
         // local universal registrar issue '"org.hyperledger.indy.sdk.ledger.TimeoutException: Timeout happens for ledger operation"'
-        url: "https://uniregistrar.io"
+        remote: true
     },
 }
 
@@ -38,7 +38,8 @@ const createDIDFromRegistrar = async (url, drivers) => {
 
         var resp
         try {
-            const registrarURL = (opts.url) ? `${opts.url}${opts.path}` : `${url}${opts.path}`
+            const registrarURL = (opts.remote) ? `${process.env.RegistrarRemoteURL}${opts.path}` : `${url}${opts.path}`
+            console.debug(`Sending create did request for driver '${driver}' to endpoint '${registrarURL}'`)
             resp = await axios.post(registrarURL, opts.options)
         } catch (error) {
             console.log(`Failed to create DID for driver ${driver}, cause ${error}`)
@@ -67,7 +68,7 @@ const createDIDFromRegistrar = async (url, drivers) => {
 }
 
 
-if (!process.env.ResolverURL) {
+if (!process.env.RegistrarLocalURL) {
     console.log("Please provide registrar endpoint for submitting requests.")
     return
 }
@@ -81,5 +82,5 @@ if (!process.env.DRIVERS) {
 const drivers = process.env.DRIVERS.split(",")
 
 // create DIDs by calling universal registrar for given drivers
-createDIDFromRegistrar(process.env.ResolverURL, drivers)
+createDIDFromRegistrar(process.env.RegistrarLocalURL, drivers)
 

--- a/scripts/uniregistrar_create_dids.sh
+++ b/scripts/uniregistrar_create_dids.sh
@@ -9,7 +9,6 @@ set -e
 echo "Running $0"
 
 ROOT=`pwd`
-REGISTRAR_URL=http://localhost:9080
 DRIVERS=driver-did-v1,driver-did-sov
 
 echo "starting universal registrar"
@@ -17,14 +16,14 @@ cd $ROOT/test/bdd/fixtures/universal-registrar
 docker-compose down --remove-orphans
 docker-compose pull && docker-compose up --force-recreate -d
 
-until $(curl --output /dev/null --silent --head --fail $REGISTRAR_URL); do
+until $(curl --output /dev/null --silent --head --fail $UNIREGISTRAR_LOCAL); do
     printf '.'
     sleep 3
 done
 
 cd $ROOT/.build
 npm install axios
-ResolverURL=${REGISTRAR_URL} DRIVERS=${DRIVERS} node ./uniregistrar-create-dids.js
+RegistrarLocalURL=${UNIREGISTRAR_LOCAL} RegistrarRemoteURL=${UNIREGISTRAR_REMOTE} DRIVERS=${DRIVERS} node ./uniregistrar-create-dids.js
 
 echo "stopping universal registrar"
 cd $ROOT/test/bdd/fixtures/universal-registrar

--- a/test/bdd/bddtests_test.go
+++ b/test/bdd/bddtests_test.go
@@ -121,7 +121,7 @@ func generateUUID() string {
 }
 
 func FeatureContext(s *godog.Suite) {
-	bddContext, err := bddctx.NewBDDContext("fixtures/keys/tls/ec-cacert.pem")
+	bddContext, err := bddctx.NewBDDContext("fixtures/keys/tls/ec-cacert.pem", "./testdata")
 	if err != nil {
 		panic(fmt.Sprintf("Error returned from NewBDDContext: %s", err))
 	}

--- a/test/bdd/features/vc_e2e_api.feature
+++ b/test/bdd/features/vc_e2e_api.feature
@@ -9,7 +9,7 @@
 Feature: Using VC REST API
 
   @e2e
-  Scenario Outline: Store, retrieve, and verify credential and presentation.
+  Scenario Outline: Store, retrieve, verify credential and presentation using different kind of profiles
     Given Profile "<profile>" is created with DID "<did>", privateKey "<privateKey>" and signatureHolder "<signatureHolder>"
     And   We can retrieve profile "<profile>" with DID "<did>"
     And   New credential is created under "<profile>" profile
@@ -26,3 +26,12 @@ Feature: Using VC REST API
       | myprofilewithdidv1 | did:v1:test:nym:z6MkrNtSzgP1j3UrY44qktv7kFkN5RGjPHGCtwry6FUkgacR | 5vckXBtWX4Fp5N1q9UfAydDm5MoY9CZjbGNnQycPNSugstn2RMJG4dY1eoUWgDSBjNvknAsea8hwLWN8m7LtmLvK | JWS |
       | myprofilewithdidelem | did:elem:EiAWdU2yih6NA2IGnLsDhkErZ8aQX6b8yKt7jHMi-ttFdQ | 5AcDTQT7Cdg1gBvz8PQpnH3xEbLCE1VQxAJV5NjVHvNjsZSfn4NaLZ77mapoi4QwZeBhcAA7MQzaFYkzJLfGjNnR | JWS |
       | myprofilewithdidsov | did:sov:danube:CDEabPCipwE51bg7KF9yXt | 22WXAJuENXAZUKZuRceBP3S6G5mrbah9WvNxRan23HvLZ7kHMBMvZoAqAwbBo9WhkYdKVa11cCySH9m2HRmFXeaq | JWS |
+
+
+  @store_retrieve_vcs
+  Scenario Outline: Store, retrieve verifiable credentials
+    When  Given "<verifiableCredential>" is stored under "<profile>" profile
+    Then  We can retrieve credential under "<profile>" profile
+    Examples:
+      |      profile      |   verifiableCredential  |
+      | transmute-profile |   transmute_vc.json     |

--- a/test/bdd/features/verifier_e2e_api.feature
+++ b/test/bdd/features/verifier_e2e_api.feature
@@ -9,11 +9,20 @@
 Feature: Verifier VC REST API
 
   @verifyCred_api
-  Scenario: Verify Credential
-    Given "Alice" has stored her transcript from the University
+  Scenario Outline: Verify Credential
+    Given "Alice" has stored her transcript "<verifiableCredential>" from the University
     Then  Employer verifies the transcript provided by "Alice"
+    Examples:
+    Examples:
+      |   verifiableCredential  |
+      |                         |
+      |     transmute_vc.json   |
 
   @verifyPresentation_api
-  Scenario: Verify Presentation
-    Given "Alice" has stored her transcript from the University
+  Scenario Outline: Verify Presentation
+    Given "Alice" has stored her transcript "<verifiablePresentation>" presented from the University
     Then  Employer verifies the transcript presented by "Alice"
+    Examples:
+      |   verifiablePresentation  |
+      |                           |
+      |     transmute_vp.json     |

--- a/test/bdd/fixtures/universalresolver/config.json
+++ b/test/bdd/fixtures/universalresolver/config.json
@@ -17,6 +17,12 @@
       "image": "universalresolver/driver-did-sov",
       "imageProperties": "true",
       "tag": "latest"
+    },
+    {
+      "pattern": "^(did:web:.+)$",
+      "image": "uport/uni-resolver-driver-did-uport",
+      "imagePort": "8081",
+      "tag": "latest"
     }
   ]
 }

--- a/test/bdd/fixtures/universalresolver/docker-compose.yml
+++ b/test/bdd/fixtures/universalresolver/docker-compose.yml
@@ -31,6 +31,13 @@ services:
     networks:
       - couchdb_bdd_net
 
+  uni-resolver-driver-did-uport:
+    image: uport/uni-resolver-driver-did-uport:1.3.1
+    ports:
+      - "8083:8081"
+    networks:
+      - couchdb_bdd_net
+
 networks:
   couchdb_bdd_net:
     external: true

--- a/test/bdd/go.mod
+++ b/test/bdd/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/cucumber/godog v0.8.1
 	github.com/fsouza/go-dockerclient v1.6.0
 	github.com/google/uuid v1.1.1
-	github.com/hyperledger/aries-framework-go v0.1.3-0.20200328075212-b14f446f90bb
+	github.com/hyperledger/aries-framework-go v0.1.3-0.20200401225228-e17df7efdb4b
 	github.com/sirupsen/logrus v1.4.2
 	github.com/trustbloc/edge-core v0.1.3-0.20200327203235-d7f232b27a56
 	github.com/trustbloc/edge-service v0.0.0

--- a/test/bdd/go.sum
+++ b/test/bdd/go.sum
@@ -161,6 +161,8 @@ github.com/hyperledger/aries-framework-go v0.1.3-0.20200326195449-859928d801a6 h
 github.com/hyperledger/aries-framework-go v0.1.3-0.20200326195449-859928d801a6/go.mod h1:ahfLvGFjR3kNGgj8xVSlaHcHHaiF6gRmF971rulr9Tg=
 github.com/hyperledger/aries-framework-go v0.1.3-0.20200328075212-b14f446f90bb h1:aT5ZKRVmrgAwfUUTlbHwQGfvJJaJhuTEePtZl66FWbM=
 github.com/hyperledger/aries-framework-go v0.1.3-0.20200328075212-b14f446f90bb/go.mod h1:ahfLvGFjR3kNGgj8xVSlaHcHHaiF6gRmF971rulr9Tg=
+github.com/hyperledger/aries-framework-go v0.1.3-0.20200401225228-e17df7efdb4b h1:OCnjgH0BGtlGt6ste6MfVWJx/lOniOc6A8sb3BuBHBM=
+github.com/hyperledger/aries-framework-go v0.1.3-0.20200401225228-e17df7efdb4b/go.mod h1:ahfLvGFjR3kNGgj8xVSlaHcHHaiF6gRmF971rulr9Tg=
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
 github.com/jessevdk/go-flags v0.0.0-20141203071132-1679536dcc89/go.mod h1:4FA24M0QyGHXBuZZK/XkWh8h0e1EYbRYJSGM75WSRxI=
 github.com/jmespath/go-jmespath v0.0.0-20180206201540-c2b33e8439af/go.mod h1:Nht3zPeWKUH0NzdCt2Blrr5ys8VGpn0CEB0cQHVjt7k=
@@ -298,10 +300,12 @@ github.com/trustbloc/edv v0.1.3-0.20200305035835-69c9f3cb077b/go.mod h1:sGaSCAXM
 github.com/trustbloc/sidetree-core-go v0.1.3-0.20200316172436-5d9ccb59942d h1:fcwBIhwy5j2dPkYtuercCkNDd0Vl3bmmixwOMRSMysk=
 github.com/trustbloc/sidetree-core-go v0.1.3-0.20200316172436-5d9ccb59942d/go.mod h1:qJ7oOPveEqrxTsO4KJsSHUM/Yivym221Dvd+IUq1V1U=
 github.com/trustbloc/sidetree-core-go v0.1.3-0.20200329202924-b30de8bf5c8a/go.mod h1:qJ7oOPveEqrxTsO4KJsSHUM/Yivym221Dvd+IUq1V1U=
+github.com/trustbloc/sidetree-core-go v0.1.3-0.20200331141546-1d1a08ef4a77 h1:WYVz7WkWqcqcTMEzHOm4u5NJmtefFAquamOneGHJvdI=
 github.com/trustbloc/sidetree-core-go v0.1.3-0.20200331141546-1d1a08ef4a77/go.mod h1:qJ7oOPveEqrxTsO4KJsSHUM/Yivym221Dvd+IUq1V1U=
 github.com/trustbloc/trustbloc-did-method v0.0.0-20200327220339-c2f631bbc668 h1:lURAaa/zfUtYzLZo1JQxH4NI9erhjS2v18Wr0HW33iM=
 github.com/trustbloc/trustbloc-did-method v0.0.0-20200327220339-c2f631bbc668/go.mod h1:m3dXqWCbp1gmeMshYOQv2Df5bDkutuEJNuvcBun1PqA=
 github.com/trustbloc/trustbloc-did-method v0.0.0-20200401180214-c51c8a66c762/go.mod h1:9+60uKTrwcac0mdCp+yyw5GyqxfSa1/el4NWF0h+iRw=
+github.com/trustbloc/trustbloc-did-method v0.0.0-20200401211047-51191c718d4a h1:C7sIPZGdgxHGSALEBqgJiLNJXK9/V3SEUevruR6EvcI=
 github.com/trustbloc/trustbloc-did-method v0.0.0-20200401211047-51191c718d4a/go.mod h1:+NGDJy6pHkLaYBosTpWQy8qto7rbdSs+NDG4TiF8ggk=
 github.com/ugorji/go v1.1.4/go.mod h1:uQMGLiO92mf5W77hV/PUCpI3pbzQx3CRekS0kk+RGrc=
 github.com/ugorji/go/codec v0.0.0-20181204163529-d75b2dcb6bc8/go.mod h1:VFNgLljTbGfSG7qAOspJ7OScBnGdDN/yBr0sguwnwf0=

--- a/test/bdd/pkg/bddutil/util.go
+++ b/test/bdd/pkg/bddutil/util.go
@@ -13,6 +13,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"reflect"
 	"strings"
 	"time"
 
@@ -102,6 +103,23 @@ func ExpectedStringError(expected, actual string) error {
 func ExpectedStatusCodeError(expected, actual int, respBytes []byte) error {
 	return fmt.Errorf("expected status code %d but got status code %d with response body %s instead",
 		expected, actual, respBytes)
+}
+
+// AreEqualJSON compares if 2 JSON bytes are equal
+func AreEqualJSON(b1, b2 []byte) (bool, error) {
+	var o1, o2 interface{}
+
+	err := json.Unmarshal(b1, &o1)
+	if err != nil {
+		return false, fmt.Errorf("error mashalling bytes 1 : %s", err.Error())
+	}
+
+	err = json.Unmarshal(b2, &o2)
+	if err != nil {
+		return false, fmt.Errorf("error mashalling bytes 2 : %s", err.Error())
+	}
+
+	return reflect.DeepEqual(o1, o2), nil
 }
 
 // CloseResponseBody closes the response body.

--- a/test/bdd/pkg/verifier/verifier_steps.go
+++ b/test/bdd/pkg/verifier/verifier_steps.go
@@ -14,7 +14,6 @@ import (
 	"net/http"
 
 	"github.com/cucumber/godog"
-	"github.com/hyperledger/aries-framework-go/pkg/doc/verifiable"
 	log "github.com/sirupsen/logrus"
 
 	"github.com/trustbloc/edge-service/pkg/restapi/vc/operation"
@@ -95,17 +94,11 @@ func (e *Steps) credentialsVerification(user string) error {
 }
 
 func (e *Steps) createAndVerifyPresentation(user string) error {
-	vcBytes := e.bddContext.Args[bddutil.GetCredentialKey(user)]
-
-	vp, err := bddutil.CreatePresentation([]byte(vcBytes), verifiable.SignatureJWS, e.bddContext.VDRI)
-	if err != nil {
-		return err
-	}
-
+	vp := e.bddContext.Args[user]
 	checks := []string{"proof"}
 
 	req := &operation.VerifyPresentationRequest{
-		Presentation: vp,
+		Presentation: []byte(vp),
 		Opts: &operation.VerifyPresentationOptions{
 			Checks: checks,
 		},

--- a/test/bdd/testdata/profile_request_template.json
+++ b/test/bdd/testdata/profile_request_template.json
@@ -1,0 +1,6 @@
+{
+  "name": "",
+  "uri": "https://example.com/credentials",
+  "signatureType": "Ed25519Signature2018",
+  "signatureRepresentation": 1
+}

--- a/test/bdd/testdata/transmute_vc.json
+++ b/test/bdd/testdata/transmute_vc.json
@@ -1,0 +1,29 @@
+{
+	"@context": [
+		"https://www.w3.org/2018/credentials/v1",
+		"https://www.w3.org/2018/credentials/examples/v1"
+	],
+	"type": [
+		"VerifiableCredential",
+		"UniversityDegreeCredential"
+	],
+	"id": "http://example.gov/credentials/3732",
+	"issuanceDate": "2020-03-16T22:37:26.544Z",
+	"credentialSubject": {
+		"id": "did:example:ebfeb1f712ebc6f1c276e12ec21",
+		"degree": {
+			"type": "BachelorDegree",
+			"degree": "MIT"
+		},
+		"name": "Jayden Doe",
+		"spouse": "did:example:c276e12ec21ebfeb1f712ebc6f1"
+	},
+	"issuer": "did:web:vc.transmute.world",
+	"proof": {
+		"type": "Ed25519Signature2018",
+		"created": "2019-12-11T03:50:55Z",
+		"verificationMethod": "did:web:vc.transmute.world#z6MksHh7qHWvybLg5QTPPdG2DgEjjduBDArV9EF9mRiRzMBN",
+		"proofPurpose": "assertionMethod",
+		"jws": "eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..MlJy4Sn47kgse7SKc56OKkJUhu-Z3CPiv2_MdjOQXJk8Bpzxa-JuinjJNN3YkYb6tPE6poIhBTlgnc_c5qQsBA"
+	}
+}

--- a/test/bdd/testdata/transmute_vp.json
+++ b/test/bdd/testdata/transmute_vp.json
@@ -1,0 +1,43 @@
+{
+	"@context": [
+		"https://www.w3.org/2018/credentials/v1",
+		"https://www.w3.org/2018/credentials/examples/v1"
+	],
+	"type": "VerifiablePresentation",
+	"verifiableCredential": {
+		"@context": [
+			"https://www.w3.org/2018/credentials/v1",
+			"https://www.w3.org/2018/credentials/examples/v1"
+		],
+		"type": [
+			"VerifiableCredential",
+			"UniversityDegreeCredential"
+		],
+		"id": "http://example.gov/credentials/3732",
+		"issuanceDate": "2020-03-16T22:37:26.544Z",
+		"credentialSubject": {
+			"id": "did:example:ebfeb1f712ebc6f1c276e12ec21",
+			"degree": {
+				"type": "BachelorDegree",
+				"degree": "MIT"
+			},
+			"name": "Jayden Doe",
+			"spouse": "did:example:c276e12ec21ebfeb1f712ebc6f1"
+		},
+		"issuer": "did:web:vc.transmute.world",
+		"proof": {
+			"type": "Ed25519Signature2018",
+			"created": "2019-12-11T03:50:55Z",
+			"verificationMethod": "did:web:vc.transmute.world#z6MksHh7qHWvybLg5QTPPdG2DgEjjduBDArV9EF9mRiRzMBN",
+			"proofPurpose": "assertionMethod",
+			"jws": "eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..MlJy4Sn47kgse7SKc56OKkJUhu-Z3CPiv2_MdjOQXJk8Bpzxa-JuinjJNN3YkYb6tPE6poIhBTlgnc_c5qQsBA"
+		}
+	},
+	"proof": {
+		"type": "Ed25519Signature2018",
+		"created": "2020-04-02T23:58:15Z",
+		"verificationMethod": "did:web:vc.transmute.world#z6MksHh7qHWvybLg5QTPPdG2DgEjjduBDArV9EF9mRiRzMBN",
+		"proofPurpose": "assertionMethod",
+		"jws": "eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..xpfST1sFKnUXNYyEJTwlQrukKETZraDv5tU7KhJldyQ0yDsykzx70ueOa9RHIqNpRIqFFFfUA9lgfY_I4VLwBg"
+	}
+}

--- a/test/bdd/testdata/university_degree_credential.json
+++ b/test/bdd/testdata/university_degree_credential.json
@@ -1,0 +1,21 @@
+{
+  "@context": [
+    "https://www.w3.org/2018/credentials/v1",
+    "https://www.w3.org/2018/credentials/examples/v1"
+  ],
+  "type": [
+    "VerifiableCredential",
+    "UniversityDegreeCredential"
+  ],
+  "id": "http://example.gov/credentials/3732",
+  "issuanceDate": "2020-03-16T22:37:26.544Z",
+  "credentialSubject": {
+    "id": "did:example:ebfeb1f712ebc6f1c276e12ec21",
+    "degree": {
+      "type": "BachelorDegree",
+      "degree": "MIT"
+    },
+    "name": "Jayden Doe",
+    "spouse": "did:example:c276e12ec21ebfeb1f712ebc6f1"
+  }
+}


### PR DESCRIPTION
- added interop tests for verifying transmute verifiable credentials and
veriable presentations issued by `vc.transmute.world`
- added make target `prepare-test-verifiables` to generate VCs and VPs
from external API endpoints.
- closes #187

Signed-off-by: sudesh.shetty <sudesh.shetty@securekey.com>