### PR TITLE
feat: bdd interop tests to verify VCs & VPs using third party verifiers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -49,6 +49,10 @@ vc-rest-docker:
 bdd-test: clean generate-test-config vc-rest-docker generate-test-keys
 	@scripts/check_integration.sh
 
+.PHONY: bdd-interop-test
+bdd-interop-test:clean generate-test-config vc-rest-docker generate-test-keys
+	@TAGS=interop scripts/check_integration.sh
+
 unit-test:
 	@scripts/check_unit.sh
 

--- a/cmd/vc-rest/go.mod
+++ b/cmd/vc-rest/go.mod
@@ -8,7 +8,7 @@ replace github.com/trustbloc/edge-service => ../..
 
 require (
 	github.com/gorilla/mux v1.7.4
-	github.com/hyperledger/aries-framework-go v0.1.3-0.20200408235155-7e4eafc4b66c
+	github.com/hyperledger/aries-framework-go v0.1.3-0.20200411010800-c043ad2f2e92
 	github.com/rs/cors v1.7.0
 	github.com/sirupsen/logrus v1.4.2
 	github.com/spf13/cobra v0.0.6

--- a/cmd/vc-rest/go.sum
+++ b/cmd/vc-rest/go.sum
@@ -120,6 +120,8 @@ github.com/hyperledger/aries-framework-go v0.1.3-0.20200408160748-24c4bd1cdda2/g
 github.com/hyperledger/aries-framework-go v0.1.3-0.20200408183828-f12cbc1b8777 h1:W+jfwKZ2fDY/JzHXx/myC344Wznl/iLxbJz6JpdQ+YY=
 github.com/hyperledger/aries-framework-go v0.1.3-0.20200408183828-f12cbc1b8777/go.mod h1:4SOyzXVQVIS/VWTEgMn4Li+xFRCWUSbUIF+ScN8JoxM=
 github.com/hyperledger/aries-framework-go v0.1.3-0.20200408235155-7e4eafc4b66c/go.mod h1:4SOyzXVQVIS/VWTEgMn4Li+xFRCWUSbUIF+ScN8JoxM=
+github.com/hyperledger/aries-framework-go v0.1.3-0.20200411010800-c043ad2f2e92 h1:lhemfcJMWVh3jtY2EyJZp35lSKKkyvu7gcGFyC2PWI8=
+github.com/hyperledger/aries-framework-go v0.1.3-0.20200411010800-c043ad2f2e92/go.mod h1:4SOyzXVQVIS/VWTEgMn4Li+xFRCWUSbUIF+ScN8JoxM=
 github.com/inconshreveable/mousetrap v1.0.0 h1:Z8tu5sraLXCXIcARxBp/8cbvlwVa7Z1NHg9XEKhtSvM=
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
 github.com/jessevdk/go-flags v0.0.0-20141203071132-1679536dcc89/go.mod h1:4FA24M0QyGHXBuZZK/XkWh8h0e1EYbRYJSGM75WSRxI=
@@ -250,6 +252,7 @@ github.com/trustbloc/sidetree-core-go v0.1.3-0.20200331141546-1d1a08ef4a77 h1:WY
 github.com/trustbloc/sidetree-core-go v0.1.3-0.20200331141546-1d1a08ef4a77/go.mod h1:qJ7oOPveEqrxTsO4KJsSHUM/Yivym221Dvd+IUq1V1U=
 github.com/trustbloc/trustbloc-did-method v0.0.0-20200408175722-457448ad951b h1:2r4sUJPYjUCF93KOtwrbGWmSDTaxvJzIqo2JvkcP/Es=
 github.com/trustbloc/trustbloc-did-method v0.0.0-20200408175722-457448ad951b/go.mod h1:tCRmxrbF0CXELc5TPWu5luwvKpxEvUL+1EQdi5JA5Rw=
+github.com/trustbloc/trustbloc-did-method v0.0.0-20200408224306-fc801792f213 h1:4ICORhvO4lE20QZnnVx7I61cckgEBM1gT5iUh+y11DI=
 github.com/trustbloc/trustbloc-did-method v0.0.0-20200408224306-fc801792f213/go.mod h1:tCRmxrbF0CXELc5TPWu5luwvKpxEvUL+1EQdi5JA5Rw=
 github.com/ugorji/go v1.1.4/go.mod h1:uQMGLiO92mf5W77hV/PUCpI3pbzQx3CRekS0kk+RGrc=
 github.com/ugorji/go/codec v0.0.0-20181204163529-d75b2dcb6bc8/go.mod h1:VFNgLljTbGfSG7qAOspJ7OScBnGdDN/yBr0sguwnwf0=

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/btcsuite/btcutil v1.0.1
 	github.com/google/uuid v1.1.1
 	github.com/gorilla/mux v1.7.4
-	github.com/hyperledger/aries-framework-go v0.1.3-0.20200408235155-7e4eafc4b66c
+	github.com/hyperledger/aries-framework-go v0.1.3-0.20200411010800-c043ad2f2e92
 	github.com/sirupsen/logrus v1.4.2
 	github.com/stretchr/testify v1.5.1
 	github.com/trustbloc/edge-core v0.1.3-0.20200318193133-ec6c4caf61ae

--- a/go.sum
+++ b/go.sum
@@ -88,6 +88,8 @@ github.com/hyperledger/aries-framework-go v0.1.3-0.20200408160748-24c4bd1cdda2 h
 github.com/hyperledger/aries-framework-go v0.1.3-0.20200408160748-24c4bd1cdda2/go.mod h1:4SOyzXVQVIS/VWTEgMn4Li+xFRCWUSbUIF+ScN8JoxM=
 github.com/hyperledger/aries-framework-go v0.1.3-0.20200408235155-7e4eafc4b66c h1:29UJcBcUpKQGaxmeh91CHc6QIRcsRy7lxYpXSGS6lQ0=
 github.com/hyperledger/aries-framework-go v0.1.3-0.20200408235155-7e4eafc4b66c/go.mod h1:4SOyzXVQVIS/VWTEgMn4Li+xFRCWUSbUIF+ScN8JoxM=
+github.com/hyperledger/aries-framework-go v0.1.3-0.20200411010800-c043ad2f2e92 h1:lhemfcJMWVh3jtY2EyJZp35lSKKkyvu7gcGFyC2PWI8=
+github.com/hyperledger/aries-framework-go v0.1.3-0.20200411010800-c043ad2f2e92/go.mod h1:4SOyzXVQVIS/VWTEgMn4Li+xFRCWUSbUIF+ScN8JoxM=
 github.com/inconshreveable/mousetrap v1.0.0 h1:Z8tu5sraLXCXIcARxBp/8cbvlwVa7Z1NHg9XEKhtSvM=
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
 github.com/jessevdk/go-flags v0.0.0-20141203071132-1679536dcc89/go.mod h1:4FA24M0QyGHXBuZZK/XkWh8h0e1EYbRYJSGM75WSRxI=

--- a/scripts/check_integration.sh
+++ b/scripts/check_integration.sh
@@ -8,6 +8,7 @@ set -e
 
 echo "Running vc integration tests..."
 PWD=`pwd`
+TAGS="${TAGS:all}"
 cd test/bdd
 go test -count=1 -v -cover . -p 1 -timeout=20m -race
 cd $PWD

--- a/scripts/create-element-did.js
+++ b/scripts/create-element-did.js
@@ -11,7 +11,7 @@ const bs58 = require('bs58')
 
 const createElementDID = async () => {
     // Instantiate the Sidetree class
-    const sidetree = new Sidetree({});
+    const sidetree = new Sidetree({parameters: {didMethodName:"elem"}});
 
     // Create did element wallet
     const wallet = await sidetree.op.getNewWallet("elem")

--- a/test/bdd/bddtests_test.go
+++ b/test/bdd/bddtests_test.go
@@ -28,6 +28,10 @@ func TestMain(m *testing.M) {
 	// default is to run all tests with tag @all
 	tags := "all"
 
+	if os.Getenv("TAGS") != "" {
+		tags = os.Getenv("TAGS")
+	}
+
 	flag.Parse()
 
 	format := "progress"

--- a/test/bdd/features/thirdparty_verifier_e2e.feature
+++ b/test/bdd/features/thirdparty_verifier_e2e.feature
@@ -1,0 +1,35 @@
+#
+# Copyright SecureKey Technologies Inc. All Rights Reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+# Below features are currently failing due to issues in third party systems.
+#  TODO: below tests should be re-run after [https://github.com/trustbloc/edge-service/issues/229] is resolved
+@interop
+@third_party_verifier
+Feature: Verifier verifiable credentials and presentations in third party endpoints
+
+  @verify_credentials
+  Scenario Outline: Verify credentials using thirdparty verifier endpoints
+    Given "Alice" has her "<credential>" issued as verifiable credential using "<did>" and "<private key>"
+    Then  "<verifier>" verifies the verifiable credential provided by "Alice"
+    Examples:
+    Examples:
+      | credential                   | verifier                                                                  | did                                                              | private key                                                                              |
+      | university_degree.json       | https://vc.transmute.world/verifier/credentials                           | did:key:z6MkjRagNiMu91DduvCvgEsqLZDVzrJzFrwahc4tXLt9DoHd         | 28xXA4NyCQinSJpaZdSuNBM4kR2GqYb8NPqAtZoGCpcRYWBcDXtzVAzpZ9BAfgV334R2FC383fiHaWWWAacRaYGs |
+      | permanent_resident_card.json | https://vc.transmute.world/verifier/credentials                           | did:key:z6MkjRagNiMu91DduvCvgEsqLZDVzrJzFrwahc4tXLt9DoHd         | 28xXA4NyCQinSJpaZdSuNBM4kR2GqYb8NPqAtZoGCpcRYWBcDXtzVAzpZ9BAfgV334R2FC383fiHaWWWAacRaYGs |
+      | permanent_resident_card.json | https://univerifier.io/danubetech/credential-verifier/0.0.1/verifications | did:v1:test:nym:z6MkrNtSzgP1j3UrY44qktv7kFkN5RGjPHGCtwry6FUkgacR | 5vckXBtWX4Fp5N1q9UfAydDm5MoY9CZjbGNnQycPNSugstn2RMJG4dY1eoUWgDSBjNvknAsea8hwLWN8m7LtmLvK |
+      | permanent_resident_card.json | https://verifier.interop.digitalbazaar.com/verifiers/credentials          | did:v1:test:nym:z6MkrNtSzgP1j3UrY44qktv7kFkN5RGjPHGCtwry6FUkgacR | 5vckXBtWX4Fp5N1q9UfAydDm5MoY9CZjbGNnQycPNSugstn2RMJG4dY1eoUWgDSBjNvknAsea8hwLWN8m7LtmLvK |
+
+#  TODO add digitalbazaar and danubetech VPs in examples below once [https://github.com/trustbloc/edge-service/issues/229] is resolved
+#  TODO below test should pass after fixing https://github.com/trustbloc/edge-service/issues/230
+  @verify_presentations
+  Scenario Outline: Verify credentials using thirdparty verifier endpoints
+    Given "Alice" has her "<credential>" issued as verifiable presentation using "<did>" and "<private key>"
+    Then  "<verifier>" verifies the verifiable presentation provided by "Alice"
+    Examples:
+    Examples:
+      | credential                   | verifier                                          | did                                                        | private key                                                                              |
+      | university_degree.json       | https://vc.transmute.world/verifier/presentations | did:key:z6MkjRagNiMu91DduvCvgEsqLZDVzrJzFrwahc4tXLt9DoHd   | 28xXA4NyCQinSJpaZdSuNBM4kR2GqYb8NPqAtZoGCpcRYWBcDXtzVAzpZ9BAfgV334R2FC383fiHaWWWAacRaYGs |
+      | permanent_resident_card.json | https://vc.transmute.world/verifier/presentations | d did:key:z6MkjRagNiMu91DduvCvgEsqLZDVzrJzFrwahc4tXLt9DoHd | 28xXA4NyCQinSJpaZdSuNBM4kR2GqYb8NPqAtZoGCpcRYWBcDXtzVAzpZ9BAfgV334R2FC383fiHaWWWAacRaYGs |

--- a/test/bdd/features/verifier_e2e_api.feature
+++ b/test/bdd/features/verifier_e2e_api.feature
@@ -4,13 +4,12 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
-@all
 @verifier_rest
 Feature: Verifier VC REST API
 
   @verifyCred_api
   Scenario Outline: Verify Credential
-    Given "Alice" has her "<credential>" verified as "<verifiable credential>"
+    Given "Alice" has her "<credential>" issued as "<verifiable credential>"
     Then  Employer verifies the verifiable credential provided by "Alice"
     Examples:
     Examples:
@@ -25,7 +24,7 @@ Feature: Verifier VC REST API
 
   @verifyPresentation_api
   Scenario Outline: Verify Presentation
-    Given "Alice" has her "<credential>" verified as "<verifiable credential>" and presentable as "<verifiable presentation>"
+    Given "Alice" has her "<credential>" issued as "<verifiable credential>" and presentable as "<verifiable presentation>"
     Then  Employer verifies the verifiable presentation provided by "Alice"
     Examples:
       | credential                   | verifiable credential | verifiable presentation |

--- a/test/bdd/go.mod
+++ b/test/bdd/go.mod
@@ -13,8 +13,9 @@ require (
 	github.com/cucumber/godog v0.8.1
 	github.com/fsouza/go-dockerclient v1.6.0
 	github.com/google/uuid v1.1.1
-	github.com/hyperledger/aries-framework-go v0.1.3-0.20200408235155-7e4eafc4b66c
+	github.com/hyperledger/aries-framework-go v0.1.3-0.20200411010800-c043ad2f2e92
 	github.com/sirupsen/logrus v1.4.2
+	github.com/stretchr/testify v1.5.1
 	github.com/trustbloc/edge-core v0.1.3-0.20200327203235-d7f232b27a56
 	github.com/trustbloc/edge-service v0.0.0
 	github.com/trustbloc/sidetree-core-go v0.1.3-0.20200331141546-1d1a08ef4a77

--- a/test/bdd/go.sum
+++ b/test/bdd/go.sum
@@ -152,6 +152,8 @@ github.com/hyperledger/aries-framework-go v0.1.3-0.20200408160748-24c4bd1cdda2/g
 github.com/hyperledger/aries-framework-go v0.1.3-0.20200408183828-f12cbc1b8777 h1:W+jfwKZ2fDY/JzHXx/myC344Wznl/iLxbJz6JpdQ+YY=
 github.com/hyperledger/aries-framework-go v0.1.3-0.20200408183828-f12cbc1b8777/go.mod h1:4SOyzXVQVIS/VWTEgMn4Li+xFRCWUSbUIF+ScN8JoxM=
 github.com/hyperledger/aries-framework-go v0.1.3-0.20200408235155-7e4eafc4b66c/go.mod h1:4SOyzXVQVIS/VWTEgMn4Li+xFRCWUSbUIF+ScN8JoxM=
+github.com/hyperledger/aries-framework-go v0.1.3-0.20200411010800-c043ad2f2e92 h1:lhemfcJMWVh3jtY2EyJZp35lSKKkyvu7gcGFyC2PWI8=
+github.com/hyperledger/aries-framework-go v0.1.3-0.20200411010800-c043ad2f2e92/go.mod h1:4SOyzXVQVIS/VWTEgMn4Li+xFRCWUSbUIF+ScN8JoxM=
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
 github.com/jessevdk/go-flags v0.0.0-20141203071132-1679536dcc89/go.mod h1:4FA24M0QyGHXBuZZK/XkWh8h0e1EYbRYJSGM75WSRxI=
 github.com/jmespath/go-jmespath v0.0.0-20180206201540-c2b33e8439af/go.mod h1:Nht3zPeWKUH0NzdCt2Blrr5ys8VGpn0CEB0cQHVjt7k=
@@ -290,6 +292,7 @@ github.com/trustbloc/sidetree-core-go v0.1.3-0.20200331141546-1d1a08ef4a77 h1:WY
 github.com/trustbloc/sidetree-core-go v0.1.3-0.20200331141546-1d1a08ef4a77/go.mod h1:qJ7oOPveEqrxTsO4KJsSHUM/Yivym221Dvd+IUq1V1U=
 github.com/trustbloc/trustbloc-did-method v0.0.0-20200408175722-457448ad951b h1:2r4sUJPYjUCF93KOtwrbGWmSDTaxvJzIqo2JvkcP/Es=
 github.com/trustbloc/trustbloc-did-method v0.0.0-20200408175722-457448ad951b/go.mod h1:tCRmxrbF0CXELc5TPWu5luwvKpxEvUL+1EQdi5JA5Rw=
+github.com/trustbloc/trustbloc-did-method v0.0.0-20200408224306-fc801792f213 h1:4ICORhvO4lE20QZnnVx7I61cckgEBM1gT5iUh+y11DI=
 github.com/trustbloc/trustbloc-did-method v0.0.0-20200408224306-fc801792f213/go.mod h1:tCRmxrbF0CXELc5TPWu5luwvKpxEvUL+1EQdi5JA5Rw=
 github.com/ugorji/go v1.1.4/go.mod h1:uQMGLiO92mf5W77hV/PUCpI3pbzQx3CRekS0kk+RGrc=
 github.com/ugorji/go/codec v0.0.0-20181204163529-d75b2dcb6bc8/go.mod h1:VFNgLljTbGfSG7qAOspJ7OScBnGdDN/yBr0sguwnwf0=

--- a/test/bdd/pkg/issuer/issuer_steps.go
+++ b/test/bdd/pkg/issuer/issuer_steps.go
@@ -84,8 +84,8 @@ func NewSteps(ctx *context.BDDContext) *Steps {
 
 // RegisterSteps registers agent steps
 func (e *Steps) RegisterSteps(s *godog.Suite) {
-	s.Step(`^"([^"]*)" has her "([^"]*)" verified as "([^"]*)"$`, e.getCredential)
-	s.Step(`^"([^"]*)" has her "([^"]*)" verified as "([^"]*)" and presentable as "([^"]*)"$`, e.getPresentation)
+	s.Step(`^"([^"]*)" has her "([^"]*)" issued as "([^"]*)"$`, e.prepareCredential)
+	s.Step(`^"([^"]*)" has her "([^"]*)" issued as "([^"]*)" and presentable as "([^"]*)"$`, e.getPresentation)
 	s.Step(`^"([^"]*)" has a DID with the public key generated from Issuer Service - Generate Keypair API$`, e.createDID)
 	s.Step(`^"([^"]*)" creates an Issuer Service profile "([^"]*)" with the DID$`, e.createIssuerProfile)
 	s.Step(`^"([^"]*)" application service verifies the credential created by Issuer Service - Issue Credential API with it's DID$`, //nolint: lll
@@ -331,25 +331,29 @@ func (e *Steps) createCredential(user, cred string) ([]byte, error) {
 	return signedVCByte, nil
 }
 
-func (e *Steps) getCredential(user, cred, verifiedCred string) error {
-	// create credential if not provided in test data file
-	if verifiedCred == "" {
+func (e *Steps) prepareCredential(user, cred, vcred string) error {
+	var credEmpty, vcredEmpty = cred == "", vcred == ""
+
+	switch {
+	case !vcredEmpty:
+		// verifiable credential found in example data.
+		vcBytes, ok := e.bddContext.TestData[vcred]
+		if !ok {
+			return fmt.Errorf("unable to find verifiable credential '%s'", vcred)
+		}
+
+		e.bddContext.Args[user] = string(vcBytes)
+	case !credEmpty:
+		// credential found in example data, create verifiable credential.
 		vcBytes, err := e.createCredential(user, cred)
 		if err != nil {
 			return err
 		}
 
 		e.bddContext.Args[bddutil.GetCredentialKey(user)] = string(vcBytes)
-
-		return nil
+	default:
+		return fmt.Errorf("invalid args, 'user' and 'credential' are mandatory")
 	}
-
-	vcBytes, ok := e.bddContext.TestData[verifiedCred]
-	if !ok {
-		return fmt.Errorf("unable to find verifiable credential '%s'", verifiedCred)
-	}
-
-	e.bddContext.Args[user] = string(vcBytes)
 
 	return nil
 }


### PR DESCRIPTION
- added new bdd test target `bdd-interop-test` to verify our verifiables
using third party verifiers to test interoperability. This target can be
used in future to test bdd scenarios involving third party systems.
- this target is not part of CI
- this target will be part of nightly/daily build once stable
- pending work on this test can be found in #229

- closes #109

Signed-off-by: sudesh.shetty <sudesh.shetty@securekey.com>