### PR TITLE
feat: issuer override and verification method for issue and compose

### DIFF
--- a/pkg/doc/vc/crypto/crypto.go
+++ b/pkg/doc/vc/crypto/crypto.go
@@ -77,6 +77,37 @@ func New(kms legacykms.KMS, kResolver keyResolver) *Crypto {
 	return &Crypto{kms: kms, kResolver: kResolver}
 }
 
+// signingOpts holds options for the signing credential
+type signingOpts struct {
+	VerificationMethod string
+	Purpose            string
+	representation     string
+}
+
+// SigningOpts is signing credential option
+type SigningOpts func(opts *signingOpts)
+
+// WithVerificationMethod is an option to pass verification method for signing
+func WithVerificationMethod(verificationMethod string) SigningOpts {
+	return func(opts *signingOpts) {
+		opts.VerificationMethod = verificationMethod
+	}
+}
+
+// WithPurpose is an option to pass proof purpose option for signing
+func WithPurpose(purpose string) SigningOpts {
+	return func(opts *signingOpts) {
+		opts.Purpose = purpose
+	}
+}
+
+// WithSigningRepresentation is an option to pass representation for signing
+func WithSigningRepresentation(representation string) SigningOpts {
+	return func(opts *signingOpts) {
+		opts.representation = representation
+	}
+}
+
 // Crypto to sign credential
 type Crypto struct {
 	kms       legacykms.KMS
@@ -84,32 +115,71 @@ type Crypto struct {
 }
 
 // SignCredential sign vc
-func (c *Crypto) SignCredential(dataProfile *vcprofile.DataProfile, vc *verifiable.Credential) (*verifiable.Credential, error) { // nolint:lll
-	var s signer
+func (c *Crypto) SignCredential(dataProfile *vcprofile.DataProfile, vc *verifiable.Credential, opts ...SigningOpts) (*verifiable.Credential, error) { // nolint:lll
+	signOpts := &signingOpts{}
+	// apply opts
+	for _, opt := range opts {
+		opt(signOpts)
+	}
 
-	s = newPrivateKeySigner(base58.Decode(dataProfile.DIDPrivateKey))
+	s, method, err := c.getSigner(dataProfile, signOpts)
+	if err != nil {
+		return nil, err
+	}
 
-	if dataProfile.DIDPrivateKey == "" {
-		var err error
-
-		s, err = newKMSSigner(c.kms, c.kResolver, dataProfile.Creator)
+	repres := dataProfile.SignatureRepresentation
+	if signOpts.representation != "" {
+		repres, err = getSignatureRepresentation(signOpts.representation)
 		if err != nil {
 			return nil, err
 		}
 	}
 
+	// TODO Matching suite and type  for signOpts.VerificationMethod [Issue #222]
 	signingCtx := &verifiable.LinkedDataProofContext{
-		VerificationMethod:      dataProfile.Creator,
-		SignatureRepresentation: dataProfile.SignatureRepresentation,
+		VerificationMethod:      method,
+		SignatureRepresentation: repres,
 		SignatureType:           dataProfile.SignatureType,
 		Suite: ed25519signature2018.New(
 			suite.WithSigner(s)),
+		Purpose: signOpts.Purpose,
 	}
 
-	err := vc.AddLinkedDataProof(signingCtx)
+	err = vc.AddLinkedDataProof(signingCtx)
 	if err != nil {
 		return nil, fmt.Errorf("failed to sign vc: %w", err)
 	}
 
 	return vc, nil
+}
+
+// getSigner returns signer and verification method based on profile and signing opts
+// verificationMethod from opts takes priority to create signer and verification method
+func (c *Crypto) getSigner(dataProfile *vcprofile.DataProfile, opts *signingOpts) (signer, string, error) {
+	switch {
+	case opts.VerificationMethod != "":
+		s, err := newKMSSigner(c.kms, c.kResolver, opts.VerificationMethod)
+		return s, opts.VerificationMethod, err
+	case dataProfile.DIDPrivateKey == "":
+		s, err := newKMSSigner(c.kms, c.kResolver, dataProfile.Creator)
+		return s, dataProfile.Creator, err
+	default:
+		return newPrivateKeySigner(base58.Decode(dataProfile.DIDPrivateKey)), dataProfile.Creator, nil
+	}
+}
+
+// getSignatureRepresentation returns signing repsentation for given representation key
+func getSignatureRepresentation(signRep string) (verifiable.SignatureRepresentation, error) {
+	var signatureRepresentation verifiable.SignatureRepresentation
+
+	switch signRep {
+	case "jws":
+		signatureRepresentation = verifiable.SignatureJWS
+	case "proofValue":
+		signatureRepresentation = verifiable.SignatureProofValue
+	default:
+		return -1, fmt.Errorf("invalid proof format : %s", signRep)
+	}
+
+	return signatureRepresentation, nil
 }

--- a/pkg/doc/vc/profile/profile.go
+++ b/pkg/doc/vc/profile/profile.go
@@ -41,6 +41,7 @@ type DataProfile struct {
 	Created                 *time.Time                         `json:"created"`
 	DIDPrivateKey           string                             `json:"didPrivateKey"`
 	DisableVCStatus         bool                               `json:"disableVCStatus"`
+	OverwriteIssuer         bool                               `json:"overwriteIssuer"`
 }
 
 // SaveProfile saves issuer profile to underlying store

--- a/pkg/doc/vc/status/csl/csl.go
+++ b/pkg/doc/vc/status/csl/csl.go
@@ -14,6 +14,8 @@ import (
 	"strings"
 	"time"
 
+	vccrypto "github.com/trustbloc/edge-service/pkg/doc/vc/crypto"
+
 	"github.com/hyperledger/aries-framework-go/pkg/doc/verifiable"
 	"github.com/trustbloc/edge-core/pkg/storage"
 
@@ -30,7 +32,8 @@ const (
 )
 
 type crypto interface {
-	SignCredential(dataProfile *vcprofile.DataProfile, vc *verifiable.Credential) (*verifiable.Credential, error)
+	SignCredential(dataProfile *vcprofile.DataProfile, vc *verifiable.Credential,
+		opts ...vccrypto.SigningOpts) (*verifiable.Credential, error)
 }
 
 // CredentialStatusManager implement spec https://w3c-ccg.github.io/vc-csl2017/

--- a/pkg/restapi/vc/operation/models.go
+++ b/pkg/restapi/vc/operation/models.go
@@ -45,6 +45,7 @@ type ProfileRequest struct {
 	DIDPrivateKey           string                             `json:"didPrivateKey"`
 	UNIRegistrar            UNIRegistrar                       `json:"uniRegistrar,omitempty"`
 	DisableVCStatus         bool                               `json:"disableVCStatus"`
+	OverwriteIssuer         bool                               `json:"overwriteIssuer,omitempty"`
 }
 
 // UNIRegistrar uni-registrar
@@ -67,10 +68,16 @@ type IssueCredentialRequest struct {
 
 // IssueCredentialOptions options for issuing credential.
 type IssueCredentialOptions struct {
-	AssertionMethod    string     `json:"assertionMethod,omitempty"`
-	VerificationMethod string     `json:"verificationMethod,omitempty"`
-	ProofPurpose       string     `json:"proofPurpose,omitempty"`
-	Created            *time.Time `json:"created,omitempty"`
+	// VerificationMethod is verification method to be used for credential proof
+	VerificationMethod string `json:"verificationMethod,omitempty"`
+	// AssertionMethod is verification method to be used for credential proof.
+	// When provided along with 'VerificationMethod' property, 'VerificationMethod' takes precedence.
+	// deprecated : to be removed in future, 'VerificationMethod' field will be used to pass verification method.
+	AssertionMethod string `json:"assertionMethod,omitempty"`
+	// ProofPurpose will be used for proof option purpose
+	ProofPurpose string `json:"proofPurpose,omitempty"`
+	// Created will be used for proof option created
+	Created *time.Time `json:"created,omitempty"`
 }
 
 // ComposeCredentialRequest for composing and issuing credential.

--- a/test/bdd/pkg/vc/vc_steps.go
+++ b/test/bdd/pkg/vc/vc_steps.go
@@ -129,6 +129,7 @@ func (e *Steps) createProfile(profileName, did, privateKey, holder, //nolint[:go
 	profileRequest.DIDPrivateKey = privateKey
 	profileRequest.SignatureRepresentation = getSignatureRepresentation(holder)
 	profileRequest.UNIRegistrar = u
+	profileRequest.OverwriteIssuer = true
 
 	requestBytes, err := json.Marshal(profileRequest)
 	if err != nil {
@@ -248,8 +249,6 @@ func (e *Steps) createCredential(credential, profileName string) error {
 		return fmt.Errorf("unable to fetch profile - %s", err)
 	}
 
-	cred.Issuer.ID = profileResponse.DID
-	cred.Issuer.Name = profileResponse.Name
 	cred.ID = profileResponse.URI + "/" + uuid.New().String()
 
 	credBytes, err := cred.MarshalJSON()


### PR DESCRIPTION
- credential issuer to be dynamically populated as per #251
- issue credential assertion method changed from DID to DID Verification
Key ID
- added purpose in issue credential options
- added putpose in compose credential options
- refactored crypto sign credential to accept dynamic opts
- updated bdd tests to use options & profile.overwriteIssuer

- Closes #239
- Closes #251

TODO:(Will be part of next PR) Avoid overriding of Credential issuer & proof options during
crdential status update

Signed-off-by: sudesh.shetty <sudesh.shetty@securekey.com>