### PR TITLE
feat: update vc status  refactor and new signing options

### DIFF
--- a/pkg/restapi/vc/operation/models.go
+++ b/pkg/restapi/vc/operation/models.go
@@ -68,15 +68,16 @@ type IssueCredentialRequest struct {
 
 // IssueCredentialOptions options for issuing credential.
 type IssueCredentialOptions struct {
-	// VerificationMethod is verification method to be used for credential proof
+	// VerificationMethod is the URI of the verificationMethod used for the proof.
+	// If omitted first ed25519 public key of DID (Issuer or Profile DID) will be used.
 	VerificationMethod string `json:"verificationMethod,omitempty"`
 	// AssertionMethod is verification method to be used for credential proof.
 	// When provided along with 'VerificationMethod' property, 'VerificationMethod' takes precedence.
 	// deprecated : to be removed in future, 'VerificationMethod' field will be used to pass verification method.
 	AssertionMethod string `json:"assertionMethod,omitempty"`
-	// ProofPurpose will be used for proof option purpose
+	// ProofPurpose is purpose of the proof. If omitted "assertionMethod" will be used.
 	ProofPurpose string `json:"proofPurpose,omitempty"`
-	// Created will be used for proof option created
+	// Created date of the proof. If omitted system time will be used.
 	Created *time.Time `json:"created,omitempty"`
 }
 

--- a/test/bdd/features/thirdparty_verifier_e2e.feature
+++ b/test/bdd/features/thirdparty_verifier_e2e.feature
@@ -16,9 +16,11 @@ Feature: Verifier verifiable credentials and presentations in third party endpoi
     Then  "<verifier>" verifies the verifiable credential provided by "Alice"
     Examples:
     Examples:
-      | credential                   | verifier                                                                  | did                                                              | private key                                                                              |
-      | university_degree.json       | https://vc.transmute.world/verifier/credentials                           | did:key:z6MkjRagNiMu91DduvCvgEsqLZDVzrJzFrwahc4tXLt9DoHd         | 28xXA4NyCQinSJpaZdSuNBM4kR2GqYb8NPqAtZoGCpcRYWBcDXtzVAzpZ9BAfgV334R2FC383fiHaWWWAacRaYGs |
-      | permanent_resident_card.json | https://vc.transmute.world/verifier/credentials                           | did:key:z6MkjRagNiMu91DduvCvgEsqLZDVzrJzFrwahc4tXLt9DoHd         | 28xXA4NyCQinSJpaZdSuNBM4kR2GqYb8NPqAtZoGCpcRYWBcDXtzVAzpZ9BAfgV334R2FC383fiHaWWWAacRaYGs |
+      | credential                   | verifier                                        | did                                                      | private key                                                                              |
+      | university_degree.json       | http://localhost:8069/verifier/credentials      | did:key:z6MkjRagNiMu91DduvCvgEsqLZDVzrJzFrwahc4tXLt9DoHd | 28xXA4NyCQinSJpaZdSuNBM4kR2GqYb8NPqAtZoGCpcRYWBcDXtzVAzpZ9BAfgV334R2FC383fiHaWWWAacRaYGs |
+      | permanent_resident_card.json | http://localhost:8069/verifier/credentials      | did:key:z6MkjRagNiMu91DduvCvgEsqLZDVzrJzFrwahc4tXLt9DoHd | 28xXA4NyCQinSJpaZdSuNBM4kR2GqYb8NPqAtZoGCpcRYWBcDXtzVAzpZ9BAfgV334R2FC383fiHaWWWAacRaYGs |
+      | university_degree.json       | https://vc.transmute.world/verifier/credentials | did:key:z6MkjRagNiMu91DduvCvgEsqLZDVzrJzFrwahc4tXLt9DoHd | 28xXA4NyCQinSJpaZdSuNBM4kR2GqYb8NPqAtZoGCpcRYWBcDXtzVAzpZ9BAfgV334R2FC383fiHaWWWAacRaYGs |
+      | permanent_resident_card.json | https://vc.transmute.world/verifier/credentials | did:key:z6MkjRagNiMu91DduvCvgEsqLZDVzrJzFrwahc4tXLt9DoHd | 28xXA4NyCQinSJpaZdSuNBM4kR2GqYb8NPqAtZoGCpcRYWBcDXtzVAzpZ9BAfgV334R2FC383fiHaWWWAacRaYGs |
 #      | permanent_resident_card.json | https://univerifier.io/danubetech/credential-verifier/0.0.1/verifications | did:v1:test:nym:z6MkrNtSzgP1j3UrY44qktv7kFkN5RGjPHGCtwry6FUkgacR | 5vckXBtWX4Fp5N1q9UfAydDm5MoY9CZjbGNnQycPNSugstn2RMJG4dY1eoUWgDSBjNvknAsea8hwLWN8m7LtmLvK |
 #      | permanent_resident_card.json | https://verifier.interop.digitalbazaar.com/verifiers/credentials          | did:v1:test:nym:z6MkrNtSzgP1j3UrY44qktv7kFkN5RGjPHGCtwry6FUkgacR | 5vckXBtWX4Fp5N1q9UfAydDm5MoY9CZjbGNnQycPNSugstn2RMJG4dY1eoUWgDSBjNvknAsea8hwLWN8m7LtmLvK |
 
@@ -29,6 +31,6 @@ Feature: Verifier verifiable credentials and presentations in third party endpoi
     Then  "<verifier>" verifies the verifiable presentation provided by "Alice"
     Examples:
     Examples:
-      | credential                   | verifier                                          | did                                                        | private key                                                                              |
-      | university_degree.json       | https://vc.transmute.world/verifier/presentations | did:key:z6MkjRagNiMu91DduvCvgEsqLZDVzrJzFrwahc4tXLt9DoHd   | 28xXA4NyCQinSJpaZdSuNBM4kR2GqYb8NPqAtZoGCpcRYWBcDXtzVAzpZ9BAfgV334R2FC383fiHaWWWAacRaYGs |
+      | credential                   | verifier                                          | did                                                      | private key                                                                              |
+      | university_degree.json       | https://vc.transmute.world/verifier/presentations | did:key:z6MkjRagNiMu91DduvCvgEsqLZDVzrJzFrwahc4tXLt9DoHd | 28xXA4NyCQinSJpaZdSuNBM4kR2GqYb8NPqAtZoGCpcRYWBcDXtzVAzpZ9BAfgV334R2FC383fiHaWWWAacRaYGs |
       | permanent_resident_card.json | https://vc.transmute.world/verifier/presentations | did:key:z6MkjRagNiMu91DduvCvgEsqLZDVzrJzFrwahc4tXLt9DoHd | 28xXA4NyCQinSJpaZdSuNBM4kR2GqYb8NPqAtZoGCpcRYWBcDXtzVAzpZ9BAfgV334R2FC383fiHaWWWAacRaYGs |

--- a/test/bdd/pkg/vc/vc_steps.go
+++ b/test/bdd/pkg/vc/vc_steps.go
@@ -14,6 +14,7 @@ import (
 	"net/http"
 	"net/url"
 	"strings"
+	"time"
 
 	"github.com/hyperledger/aries-framework-go/pkg/doc/signature/suite"
 	"github.com/hyperledger/aries-framework-go/pkg/doc/signature/suite/ed25519signature2018"
@@ -331,6 +332,7 @@ func (e *Steps) createProfileAndPresentation(user, credential, did, privateKey s
 		return err
 	}
 
+	created := time.Now()
 	signatureSuite := ed25519signature2018.New(suite.WithSigner(bddutil.GetSigner(signingKey)))
 
 	ldpContext := &verifiable.LinkedDataProofContext{
@@ -341,6 +343,7 @@ func (e *Steps) createProfileAndPresentation(user, credential, did, privateKey s
 		Domain:                  "issuer.example.com",
 		Challenge:               uuid.New().String(),
 		Purpose:                 "authentication",
+		Created:                 &created,
 	}
 
 	vp, err := bddutil.CreateCustomPresentation(e.bddContext.CreatedCredential, e.bddContext.VDRI, ldpContext)


### PR DESCRIPTION
- changed vc status update logic to preserve issuer and proof options
from original VC
- added created proof options support for issue and compose credential
- added bdd test step for creating and veifying VCs with 'did:key'
- Closes #273
- Closes #291
- Closes #269
- Closes #255

Signed-off-by: sudesh.shetty <sudesh.shetty@securekey.com>