### PR TITLE
fix: #464 double testSleep for BDD tests

### DIFF
--- a/test/bdd/bddtests_test.go
+++ b/test/bdd/bddtests_test.go
@@ -73,7 +73,7 @@ func runBDDTests(tags, format string) int {
 					composition = append(composition, newComposition)
 				}
 				fmt.Println("docker-compose up ... waiting for containers to start ...")
-				testSleep := 15
+				testSleep := 30
 				if os.Getenv("TEST_SLEEP") != "" {
 					var e error
 


### PR DESCRIPTION
For #464 

I kept getting the following error while trying to reproduce the user's error:

```
expected status code 201 but got status code 400 with response body {"errMessage":"failed to create did doc from uni-registrar: Post http://uni-registrar-web:9080/1.0/register?driverId=driver-did-method-rest: dial tcp 172.27.0.20:9080: connect: connection refused"}
```

This change allows universalregistrar/uni-registrar-web more startup time.

Signed-off-by: George Aristy <george.aristy@securekey.com>