### PR TITLE
chore: Update edv and edge-core versions

### DIFF
--- a/cmd/did-rest/go.mod
+++ b/cmd/did-rest/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/rs/cors v1.7.0
 	github.com/spf13/cobra v0.0.6
 	github.com/stretchr/testify v1.5.1
-	github.com/trustbloc/edge-core v0.1.4-0.20200708225443-dcc42296cada
+	github.com/trustbloc/edge-core v0.1.4-0.20200814194611-5f3b95f18b63
 	github.com/trustbloc/edge-service v0.0.0
 )
 

--- a/cmd/did-rest/go.sum
+++ b/cmd/did-rest/go.sum
@@ -26,6 +26,7 @@ github.com/btcsuite/goleveldb v0.0.0-20160330041536-7834afc9e8cd/go.mod h1:F+uVa
 github.com/btcsuite/snappy-go v0.0.0-20151229074030-0bdef8d06723/go.mod h1:8woku9dyThutzjeg+3xrA5iCpBRH8XEEg3lh6TiUghc=
 github.com/btcsuite/websocket v0.0.0-20150119174127-31079b680792/go.mod h1:ghJtEyQwv5/p4Mg4C0fgbePVuGr935/5ddU9Z3TmDRY=
 github.com/btcsuite/winsvc v1.0.0/go.mod h1:jsenWakMcC0zFBFurPLEAyrnc/teJEM1O46fmI40EZs=
+github.com/cenkalti/backoff v2.2.1+incompatible/go.mod h1:90ReRw6GdpyfrHakVjL/QHaoyV4aDUVVkXQJJJ3NXXM=
 github.com/cespare/xxhash v1.1.0 h1:a6HrQnmkObjyL+Gs60czilIUGqrzKutQD6XZog3p+ko=
 github.com/cespare/xxhash v1.1.0/go.mod h1:XrSqR1VqqWfGrhpAt58auRo0WTKS1nRRg3ghfAqPWnc=
 github.com/cespare/xxhash/v2 v2.1.1 h1:6MnRN8NT7+YBpUIWxHtefFZOKTAPgGjpQSxqLNn0+qY=
@@ -215,11 +216,9 @@ github.com/syndtr/goleveldb v1.0.0/go.mod h1:ZVVdQEZoIme9iO1Ch2Jdy24qqXrMMOU6lpP
 github.com/teserakt-io/golang-ed25519 v0.0.0-20200315192543-8255be791ce4 h1:Sq/68UWgBzKT+pLTUTkSf0jS2IUwwXLFlZmeh+nAzQM=
 github.com/teserakt-io/golang-ed25519 v0.0.0-20200315192543-8255be791ce4/go.mod h1:9PdLyPiZIiW3UopXyRnPYyjUXSpiQNHRLu8fOsR3o8M=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
-github.com/trustbloc/edge-core v0.1.4-0.20200603140750-8d89a0084be7 h1:RMMMKvUKjg9WXWLA63Ltuf3RgkWhedpK/1geY48E34I=
-github.com/trustbloc/edge-core v0.1.4-0.20200603140750-8d89a0084be7/go.mod h1:WHyxnukpb4wUXDLdgJ/vQY0JIZ9HfONzK/ERzpGVOgk=
-github.com/trustbloc/edge-core v0.1.4-0.20200708225443-dcc42296cada h1:x3fKt4Brg5x3rHub1AfgVt4rrWdMnebvPEQpA4vP12M=
-github.com/trustbloc/edge-core v0.1.4-0.20200708225443-dcc42296cada/go.mod h1:SZg7nAIc9FONS+G7MwEyGkCWCJR3R02bePwTpWxqH5w=
-github.com/trustbloc/edv v0.1.4-0.20200612202422-540ab6ea9def/go.mod h1:3eOkVgjlLq50N5eqdOhjsOKbModJKlwXxdFg18BNePE=
+github.com/trustbloc/edge-core v0.1.4-0.20200814194611-5f3b95f18b63 h1:gwdHQvxLWX2wrTSj/NlhQ9ZgHUmLmx5Iok/8qaYOhQQ=
+github.com/trustbloc/edge-core v0.1.4-0.20200814194611-5f3b95f18b63/go.mod h1:mTU1E/HcKcjmHaPCjBOvHERuryGhh5zgVkRSi4slAHg=
+github.com/trustbloc/edv v0.1.4-0.20200815210630-993f07543815/go.mod h1:TI2UGPN00OOoo/kdTMLstV+lUodsp0U3tCqhcdUQp2s=
 github.com/trustbloc/sidetree-core-go v0.1.4-0.20200702215916-b02022f5ec37/go.mod h1:xCuMVdRtXiCghr58Dcd1RW9t0lCDXPPjkSiACzKGaZc=
 github.com/trustbloc/trustbloc-did-method v0.1.4-0.20200709150904-54a502143328/go.mod h1:u8KKRNZj3Izs1zBFKhjqSn6TlX8qlrb7P1q+c/Aa8D0=
 github.com/trustbloc/trustbloc-did-method v0.1.4-0.20200811134027-539ff50d182f/go.mod h1:u8KKRNZj3Izs1zBFKhjqSn6TlX8qlrb7P1q+c/Aa8D0=

--- a/cmd/vc-rest/go.mod
+++ b/cmd/vc-rest/go.mod
@@ -11,9 +11,9 @@ require (
 	github.com/rs/cors v1.7.0
 	github.com/spf13/cobra v0.0.6
 	github.com/stretchr/testify v1.5.1
-	github.com/trustbloc/edge-core v0.1.4-0.20200708225443-dcc42296cada
+	github.com/trustbloc/edge-core v0.1.4-0.20200814194611-5f3b95f18b63
 	github.com/trustbloc/edge-service v0.0.0
-	github.com/trustbloc/edv v0.1.4-0.20200612202422-540ab6ea9def
+	github.com/trustbloc/edv v0.1.4-0.20200815210630-993f07543815
 	github.com/trustbloc/trustbloc-did-method v0.1.4-0.20200811134027-539ff50d182f
 )
 

--- a/cmd/vc-rest/go.sum
+++ b/cmd/vc-rest/go.sum
@@ -28,6 +28,7 @@ github.com/btcsuite/goleveldb v0.0.0-20160330041536-7834afc9e8cd/go.mod h1:F+uVa
 github.com/btcsuite/snappy-go v0.0.0-20151229074030-0bdef8d06723/go.mod h1:8woku9dyThutzjeg+3xrA5iCpBRH8XEEg3lh6TiUghc=
 github.com/btcsuite/websocket v0.0.0-20150119174127-31079b680792/go.mod h1:ghJtEyQwv5/p4Mg4C0fgbePVuGr935/5ddU9Z3TmDRY=
 github.com/btcsuite/winsvc v1.0.0/go.mod h1:jsenWakMcC0zFBFurPLEAyrnc/teJEM1O46fmI40EZs=
+github.com/cenkalti/backoff v2.2.1+incompatible/go.mod h1:90ReRw6GdpyfrHakVjL/QHaoyV4aDUVVkXQJJJ3NXXM=
 github.com/cespare/xxhash v1.1.0 h1:a6HrQnmkObjyL+Gs60czilIUGqrzKutQD6XZog3p+ko=
 github.com/cespare/xxhash v1.1.0/go.mod h1:XrSqR1VqqWfGrhpAt58auRo0WTKS1nRRg3ghfAqPWnc=
 github.com/cespare/xxhash/v2 v2.1.1 h1:6MnRN8NT7+YBpUIWxHtefFZOKTAPgGjpQSxqLNn0+qY=
@@ -223,12 +224,10 @@ github.com/syndtr/goleveldb v1.0.0/go.mod h1:ZVVdQEZoIme9iO1Ch2Jdy24qqXrMMOU6lpP
 github.com/teserakt-io/golang-ed25519 v0.0.0-20200315192543-8255be791ce4 h1:Sq/68UWgBzKT+pLTUTkSf0jS2IUwwXLFlZmeh+nAzQM=
 github.com/teserakt-io/golang-ed25519 v0.0.0-20200315192543-8255be791ce4/go.mod h1:9PdLyPiZIiW3UopXyRnPYyjUXSpiQNHRLu8fOsR3o8M=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
-github.com/trustbloc/edge-core v0.1.4-0.20200603140750-8d89a0084be7 h1:RMMMKvUKjg9WXWLA63Ltuf3RgkWhedpK/1geY48E34I=
-github.com/trustbloc/edge-core v0.1.4-0.20200603140750-8d89a0084be7/go.mod h1:WHyxnukpb4wUXDLdgJ/vQY0JIZ9HfONzK/ERzpGVOgk=
-github.com/trustbloc/edge-core v0.1.4-0.20200708225443-dcc42296cada h1:x3fKt4Brg5x3rHub1AfgVt4rrWdMnebvPEQpA4vP12M=
-github.com/trustbloc/edge-core v0.1.4-0.20200708225443-dcc42296cada/go.mod h1:SZg7nAIc9FONS+G7MwEyGkCWCJR3R02bePwTpWxqH5w=
-github.com/trustbloc/edv v0.1.4-0.20200612202422-540ab6ea9def h1:JNR2xUWa7az7+EH24zjqMxmrdws795mIVmtAByR2SjQ=
-github.com/trustbloc/edv v0.1.4-0.20200612202422-540ab6ea9def/go.mod h1:3eOkVgjlLq50N5eqdOhjsOKbModJKlwXxdFg18BNePE=
+github.com/trustbloc/edge-core v0.1.4-0.20200814194611-5f3b95f18b63 h1:gwdHQvxLWX2wrTSj/NlhQ9ZgHUmLmx5Iok/8qaYOhQQ=
+github.com/trustbloc/edge-core v0.1.4-0.20200814194611-5f3b95f18b63/go.mod h1:mTU1E/HcKcjmHaPCjBOvHERuryGhh5zgVkRSi4slAHg=
+github.com/trustbloc/edv v0.1.4-0.20200815210630-993f07543815 h1:ydIfG34jrvFRohgsFIpW7301PA6IYoUSmNrUVqAy9I8=
+github.com/trustbloc/edv v0.1.4-0.20200815210630-993f07543815/go.mod h1:TI2UGPN00OOoo/kdTMLstV+lUodsp0U3tCqhcdUQp2s=
 github.com/trustbloc/json-gold v0.3.1-0.20200414173446-30d742ee949e h1:i+hGa8C1MKGO71j3jIV7e2aKX72/DTrzLjq9R8kc6xk=
 github.com/trustbloc/json-gold v0.3.1-0.20200414173446-30d742ee949e/go.mod h1:OK1z7UgtBZk06n2cDE2OSq1kffmjFFp5/2yhLLCz9UM=
 github.com/trustbloc/sidetree-core-go v0.1.4-0.20200702215916-b02022f5ec37 h1:eXOLEJDXvu8ek0GkthyVNWGyE6/CnlsMeNOPSaX3IkM=

--- a/go.mod
+++ b/go.mod
@@ -14,8 +14,8 @@ require (
 	github.com/hyperledger/aries-framework-go v0.1.4-0.20200528153636-1d4c39e41ae7
 	github.com/sirupsen/logrus v1.4.2
 	github.com/stretchr/testify v1.5.1
-	github.com/trustbloc/edge-core v0.1.4-0.20200708225443-dcc42296cada
-	github.com/trustbloc/edv v0.1.4-0.20200612202422-540ab6ea9def
+	github.com/trustbloc/edge-core v0.1.4-0.20200814194611-5f3b95f18b63
+	github.com/trustbloc/edv v0.1.4-0.20200815210630-993f07543815
 	github.com/trustbloc/trustbloc-did-method v0.1.4-0.20200811134027-539ff50d182f
 )
 

--- a/go.sum
+++ b/go.sum
@@ -28,6 +28,7 @@ github.com/btcsuite/goleveldb v0.0.0-20160330041536-7834afc9e8cd/go.mod h1:F+uVa
 github.com/btcsuite/snappy-go v0.0.0-20151229074030-0bdef8d06723/go.mod h1:8woku9dyThutzjeg+3xrA5iCpBRH8XEEg3lh6TiUghc=
 github.com/btcsuite/websocket v0.0.0-20150119174127-31079b680792/go.mod h1:ghJtEyQwv5/p4Mg4C0fgbePVuGr935/5ddU9Z3TmDRY=
 github.com/btcsuite/winsvc v1.0.0/go.mod h1:jsenWakMcC0zFBFurPLEAyrnc/teJEM1O46fmI40EZs=
+github.com/cenkalti/backoff v2.2.1+incompatible/go.mod h1:90ReRw6GdpyfrHakVjL/QHaoyV4aDUVVkXQJJJ3NXXM=
 github.com/cespare/xxhash v1.1.0 h1:a6HrQnmkObjyL+Gs60czilIUGqrzKutQD6XZog3p+ko=
 github.com/cespare/xxhash v1.1.0/go.mod h1:XrSqR1VqqWfGrhpAt58auRo0WTKS1nRRg3ghfAqPWnc=
 github.com/cespare/xxhash/v2 v2.1.1 h1:6MnRN8NT7+YBpUIWxHtefFZOKTAPgGjpQSxqLNn0+qY=
@@ -218,12 +219,10 @@ github.com/syndtr/goleveldb v1.0.0/go.mod h1:ZVVdQEZoIme9iO1Ch2Jdy24qqXrMMOU6lpP
 github.com/teserakt-io/golang-ed25519 v0.0.0-20200315192543-8255be791ce4 h1:Sq/68UWgBzKT+pLTUTkSf0jS2IUwwXLFlZmeh+nAzQM=
 github.com/teserakt-io/golang-ed25519 v0.0.0-20200315192543-8255be791ce4/go.mod h1:9PdLyPiZIiW3UopXyRnPYyjUXSpiQNHRLu8fOsR3o8M=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
-github.com/trustbloc/edge-core v0.1.4-0.20200603140750-8d89a0084be7 h1:RMMMKvUKjg9WXWLA63Ltuf3RgkWhedpK/1geY48E34I=
-github.com/trustbloc/edge-core v0.1.4-0.20200603140750-8d89a0084be7/go.mod h1:WHyxnukpb4wUXDLdgJ/vQY0JIZ9HfONzK/ERzpGVOgk=
-github.com/trustbloc/edge-core v0.1.4-0.20200708225443-dcc42296cada h1:x3fKt4Brg5x3rHub1AfgVt4rrWdMnebvPEQpA4vP12M=
-github.com/trustbloc/edge-core v0.1.4-0.20200708225443-dcc42296cada/go.mod h1:SZg7nAIc9FONS+G7MwEyGkCWCJR3R02bePwTpWxqH5w=
-github.com/trustbloc/edv v0.1.4-0.20200612202422-540ab6ea9def h1:JNR2xUWa7az7+EH24zjqMxmrdws795mIVmtAByR2SjQ=
-github.com/trustbloc/edv v0.1.4-0.20200612202422-540ab6ea9def/go.mod h1:3eOkVgjlLq50N5eqdOhjsOKbModJKlwXxdFg18BNePE=
+github.com/trustbloc/edge-core v0.1.4-0.20200814194611-5f3b95f18b63 h1:gwdHQvxLWX2wrTSj/NlhQ9ZgHUmLmx5Iok/8qaYOhQQ=
+github.com/trustbloc/edge-core v0.1.4-0.20200814194611-5f3b95f18b63/go.mod h1:mTU1E/HcKcjmHaPCjBOvHERuryGhh5zgVkRSi4slAHg=
+github.com/trustbloc/edv v0.1.4-0.20200815210630-993f07543815 h1:ydIfG34jrvFRohgsFIpW7301PA6IYoUSmNrUVqAy9I8=
+github.com/trustbloc/edv v0.1.4-0.20200815210630-993f07543815/go.mod h1:TI2UGPN00OOoo/kdTMLstV+lUodsp0U3tCqhcdUQp2s=
 github.com/trustbloc/json-gold v0.3.1-0.20200414173446-30d742ee949e h1:i+hGa8C1MKGO71j3jIV7e2aKX72/DTrzLjq9R8kc6xk=
 github.com/trustbloc/json-gold v0.3.1-0.20200414173446-30d742ee949e/go.mod h1:OK1z7UgtBZk06n2cDE2OSq1kffmjFFp5/2yhLLCz9UM=
 github.com/trustbloc/sidetree-core-go v0.1.4-0.20200702215916-b02022f5ec37 h1:eXOLEJDXvu8ek0GkthyVNWGyE6/CnlsMeNOPSaX3IkM=

--- a/pkg/doc/vc/profile/profile.go
+++ b/pkg/doc/vc/profile/profile.go
@@ -7,6 +7,7 @@ package profile
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"time"
 
@@ -29,7 +30,7 @@ const (
 func New(provider storage.Provider) (*Profile, error) {
 	err := provider.CreateStore(credentialStoreName)
 	if err != nil {
-		if err != storage.ErrDuplicateStore {
+		if !errors.Is(err, storage.ErrDuplicateStore) {
 			return nil, err
 		}
 	}

--- a/pkg/doc/vc/profile/verifier/profile.go
+++ b/pkg/doc/vc/profile/verifier/profile.go
@@ -8,6 +8,7 @@ package verifier
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 
 	"github.com/trustbloc/edge-core/pkg/storage"
@@ -36,7 +37,7 @@ type ProfileData struct {
 // New returns new credential recorder instance
 func New(provider storage.Provider) (*Profile, error) {
 	err := provider.CreateStore(storeName)
-	if err != nil && err != storage.ErrDuplicateStore {
+	if err != nil && !errors.Is(err, storage.ErrDuplicateStore) {
 		return nil, err
 	}
 

--- a/pkg/doc/vc/status/csl/csl.go
+++ b/pkg/doc/vc/status/csl/csl.go
@@ -74,7 +74,7 @@ type VCStatus struct {
 func New(provider storage.Provider, url string, listSize int, c crypto) (*CredentialStatusManager, error) {
 	err := provider.CreateStore(credentialStatusStore)
 	if err != nil {
-		if err != storage.ErrDuplicateStore {
+		if !errors.Is(err, storage.ErrDuplicateStore) {
 			return nil, err
 		}
 	}

--- a/pkg/doc/vc/status/csl/csl_test.go
+++ b/pkg/doc/vc/status/csl/csl_test.go
@@ -451,6 +451,10 @@ func (s *mockStore) Query(query string) (storage.ResultsIterator, error) {
 	return nil, nil
 }
 
+func (s *mockStore) Delete(k string) error {
+	panic("implement me")
+}
+
 // nolint: unparam
 func createDIDDoc(didID string) *did.Doc {
 	const (

--- a/pkg/restapi/internal/common/vcutil/vcutil.go
+++ b/pkg/restapi/internal/common/vcutil/vcutil.go
@@ -7,14 +7,13 @@ SPDX-License-Identifier: Apache-2.0
 package vcutil
 
 import (
-	"crypto/rand"
 	"encoding/json"
 	"errors"
 	"fmt"
 	"strings"
 
-	"github.com/btcsuite/btcutil/base58"
 	"github.com/hyperledger/aries-framework-go/pkg/doc/verifiable"
+	"github.com/trustbloc/edv/pkg/edvutils"
 	"github.com/trustbloc/edv/pkg/restapi/models"
 
 	"github.com/trustbloc/edge-service/pkg/doc/vc/crypto"
@@ -97,7 +96,7 @@ func DecodeTypedIDFromJSONRaw(typedIDBytes json.RawMessage) ([]verifiable.TypedI
 
 // BuildStructuredDocForStorage builds structured data for storage from given VC
 func BuildStructuredDocForStorage(vcData []byte) (*models.StructuredDocument, error) {
-	edvDocID, err := generateEDVCompatibleID()
+	edvDocID, err := edvutils.GenerateEDVCompatibleID()
 	if err != nil {
 		return nil, err
 	}
@@ -138,18 +137,4 @@ func GetDocIDFromURL(docURL string) string {
 	docIDToRetrieve := splitBySlashes[len(splitBySlashes)-1]
 
 	return docIDToRetrieve
-}
-
-// generateEDVCompatibleID generates EDV compatible IDs
-func generateEDVCompatibleID() (string, error) {
-	randomBytes := make([]byte, 16)
-
-	_, err := rand.Read(randomBytes)
-	if err != nil {
-		return "", err
-	}
-
-	base58EncodedUUID := base58.Encode(randomBytes)
-
-	return base58EncodedUUID, nil
 }

--- a/test/bdd/fixtures/edv-rest/.env
+++ b/test/bdd/fixtures/edv-rest/.env
@@ -5,7 +5,7 @@
 #
 
 EDV_REST_IMAGE=docker.pkg.github.com/trustbloc-cicd/snapshot/edv-rest
-EDV_REST_IMAGE_TAG=0.1.4-snapshot-540ab6e
+EDV_REST_IMAGE_TAG=0.1.4-snapshot-993f075
 
 EDV_HOST=0.0.0.0
 EDV_PORT=8071

--- a/test/bdd/go.mod
+++ b/test/bdd/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/google/uuid v1.1.1
 	github.com/hyperledger/aries-framework-go v0.1.4-0.20200528153636-1d4c39e41ae7
 	github.com/mr-tron/base58 v1.1.3
-	github.com/trustbloc/edge-core v0.1.4-0.20200708225443-dcc42296cada
+	github.com/trustbloc/edge-core v0.1.4-0.20200814194611-5f3b95f18b63
 	github.com/trustbloc/edge-service v0.0.0
 	github.com/trustbloc/trustbloc-did-method v0.1.4-0.20200811134027-539ff50d182f
 )

--- a/test/bdd/go.sum
+++ b/test/bdd/go.sum
@@ -35,6 +35,7 @@ github.com/btcsuite/goleveldb v0.0.0-20160330041536-7834afc9e8cd/go.mod h1:F+uVa
 github.com/btcsuite/snappy-go v0.0.0-20151229074030-0bdef8d06723/go.mod h1:8woku9dyThutzjeg+3xrA5iCpBRH8XEEg3lh6TiUghc=
 github.com/btcsuite/websocket v0.0.0-20150119174127-31079b680792/go.mod h1:ghJtEyQwv5/p4Mg4C0fgbePVuGr935/5ddU9Z3TmDRY=
 github.com/btcsuite/winsvc v1.0.0/go.mod h1:jsenWakMcC0zFBFurPLEAyrnc/teJEM1O46fmI40EZs=
+github.com/cenkalti/backoff v2.2.1+incompatible/go.mod h1:90ReRw6GdpyfrHakVjL/QHaoyV4aDUVVkXQJJJ3NXXM=
 github.com/cespare/xxhash v1.1.0 h1:a6HrQnmkObjyL+Gs60czilIUGqrzKutQD6XZog3p+ko=
 github.com/cespare/xxhash v1.1.0/go.mod h1:XrSqR1VqqWfGrhpAt58auRo0WTKS1nRRg3ghfAqPWnc=
 github.com/cespare/xxhash/v2 v2.1.1 h1:6MnRN8NT7+YBpUIWxHtefFZOKTAPgGjpQSxqLNn0+qY=
@@ -266,12 +267,10 @@ github.com/syndtr/goleveldb v1.0.0/go.mod h1:ZVVdQEZoIme9iO1Ch2Jdy24qqXrMMOU6lpP
 github.com/teserakt-io/golang-ed25519 v0.0.0-20200315192543-8255be791ce4 h1:Sq/68UWgBzKT+pLTUTkSf0jS2IUwwXLFlZmeh+nAzQM=
 github.com/teserakt-io/golang-ed25519 v0.0.0-20200315192543-8255be791ce4/go.mod h1:9PdLyPiZIiW3UopXyRnPYyjUXSpiQNHRLu8fOsR3o8M=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
-github.com/trustbloc/edge-core v0.1.4-0.20200603140750-8d89a0084be7 h1:RMMMKvUKjg9WXWLA63Ltuf3RgkWhedpK/1geY48E34I=
-github.com/trustbloc/edge-core v0.1.4-0.20200603140750-8d89a0084be7/go.mod h1:WHyxnukpb4wUXDLdgJ/vQY0JIZ9HfONzK/ERzpGVOgk=
-github.com/trustbloc/edge-core v0.1.4-0.20200708225443-dcc42296cada h1:x3fKt4Brg5x3rHub1AfgVt4rrWdMnebvPEQpA4vP12M=
-github.com/trustbloc/edge-core v0.1.4-0.20200708225443-dcc42296cada/go.mod h1:SZg7nAIc9FONS+G7MwEyGkCWCJR3R02bePwTpWxqH5w=
-github.com/trustbloc/edv v0.1.4-0.20200612202422-540ab6ea9def h1:JNR2xUWa7az7+EH24zjqMxmrdws795mIVmtAByR2SjQ=
-github.com/trustbloc/edv v0.1.4-0.20200612202422-540ab6ea9def/go.mod h1:3eOkVgjlLq50N5eqdOhjsOKbModJKlwXxdFg18BNePE=
+github.com/trustbloc/edge-core v0.1.4-0.20200814194611-5f3b95f18b63 h1:gwdHQvxLWX2wrTSj/NlhQ9ZgHUmLmx5Iok/8qaYOhQQ=
+github.com/trustbloc/edge-core v0.1.4-0.20200814194611-5f3b95f18b63/go.mod h1:mTU1E/HcKcjmHaPCjBOvHERuryGhh5zgVkRSi4slAHg=
+github.com/trustbloc/edv v0.1.4-0.20200815210630-993f07543815 h1:ydIfG34jrvFRohgsFIpW7301PA6IYoUSmNrUVqAy9I8=
+github.com/trustbloc/edv v0.1.4-0.20200815210630-993f07543815/go.mod h1:TI2UGPN00OOoo/kdTMLstV+lUodsp0U3tCqhcdUQp2s=
 github.com/trustbloc/json-gold v0.3.1-0.20200414173446-30d742ee949e h1:i+hGa8C1MKGO71j3jIV7e2aKX72/DTrzLjq9R8kc6xk=
 github.com/trustbloc/json-gold v0.3.1-0.20200414173446-30d742ee949e/go.mod h1:OK1z7UgtBZk06n2cDE2OSq1kffmjFFp5/2yhLLCz9UM=
 github.com/trustbloc/sidetree-core-go v0.1.4-0.20200702215916-b02022f5ec37 h1:eXOLEJDXvu8ek0GkthyVNWGyE6/CnlsMeNOPSaX3IkM=


### PR DESCRIPTION
- Updates edge-core dependency (includes trustbloc/edge-core#52, trustbloc/edge-core#55)
- updates edv dependency and Docker image (also includes the above edge-core updates)

Signed-off-by: Derek Trider <Derek.Trider@securekey.com>