### PR TITLE
fix: Removed incorrect warning, minor code refactor

### DIFF
--- a/cmd/vc-rest/startcmd/start_test.go
+++ b/cmd/vc-rest/startcmd/start_test.go
@@ -307,9 +307,7 @@ func TestCreateProviders(t *testing.T) {
 
 func TestCreateKMS(t *testing.T) {
 	t.Run("fail to open master key store", func(t *testing.T) {
-		localKMS, err := createKMS(&edgeServiceProviders{
-			kmsSecretsProvider: &ariesmockstorage.MockStoreProvider{FailNamespace: "masterkey"},
-		})
+		localKMS, err := createKMS(&ariesmockstorage.MockStoreProvider{FailNamespace: "masterkey"})
 
 		require.Nil(t, localKMS)
 		require.EqualError(t, err, "failed to open store for name space masterkey")
@@ -326,9 +324,7 @@ func TestCreateKMS(t *testing.T) {
 		err := masterKeyStore.Put("masterkey", []byte(""))
 		require.NoError(t, err)
 
-		localKMS, err := createKMS(&edgeServiceProviders{
-			kmsSecretsProvider: &ariesmockstorage.MockStoreProvider{Store: &masterKeyStore},
-		})
+		localKMS, err := createKMS(&ariesmockstorage.MockStoreProvider{Store: &masterKeyStore})
 		require.EqualError(t, err, "masterKeyReader is empty")
 		require.Nil(t, localKMS)
 	})


### PR DESCRIPTION
- Removed warning that would get logged when using the same database for the non-KMS provider and KMS provider. The warning was effectively assuming that the database used for the non-KMS provider will also host the EDV, which doesn't make sense.
- Refactored the createKMS method to only take in the provider it needs, instead of taking in the whole struct. This makes what the method actually needs more clear.

Signed-off-by: Derek Trider <Derek.Trider@securekey.com>