### PR TITLE
fix: Missing key ID

### DIFF
--- a/pkg/internal/cryptosetup/cryptosetup.go
+++ b/pkg/internal/cryptosetup/cryptosetup.go
@@ -134,7 +134,9 @@ func prepareKeyHandle(storeProvider storage.Provider, keyManager kms.KeyManager,
 		return "", nil, err
 	}
 
-	keyHandleUntyped, getErr := keyManager.Get(string(keyIDBytes))
+	keyID := string(keyIDBytes)
+
+	keyHandleUntyped, getErr := keyManager.Get(keyID)
 	if getErr != nil {
 		return "", nil, getErr
 	}
@@ -144,7 +146,7 @@ func prepareKeyHandle(storeProvider storage.Provider, keyManager kms.KeyManager,
 		return "", nil, errKeySetHandleAssertionFailure
 	}
 
-	return "", kh, nil
+	return keyID, kh, nil
 }
 
 func prepareKeyIDStore(storeProvider storage.Provider) (storage.Store, error) {


### PR DESCRIPTION
- Fixes an issue where the  JWE encrypter is missing the key ID when reusing the existing local key ID from storage.

Signed-off-by: Derek Trider <Derek.Trider@securekey.com>