### PR TITLE
fix: confidential-storage-hub - make profile.ID a URN

### DIFF
--- a/pkg/restapi/csh/operation/operations.go
+++ b/pkg/restapi/csh/operation/operations.go
@@ -141,7 +141,7 @@ func (o *Operation) CreateProfile(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	profile.ID = uuid.New().String()
+	profile.ID = uuid.New().URN()
 
 	zcap, err := o.newProfileZCAP(profile.ID, *profile.Controller)
 	if err != nil {


### PR DESCRIPTION
Otherwise creating child zcaps fails when setting the parent zcap's ID in the capability chain.

Signed-off-by: George Aristy <george.aristy@securekey.com>