### PR TITLE
fix: generates a random nonce if not provided for deriveCredentials

### DIFF
--- a/pkg/restapi/holder/operation/operations.go
+++ b/pkg/restapi/holder/operation/operations.go
@@ -14,6 +14,7 @@ import (
 	"net/http"
 	"time"
 
+	"github.com/google/uuid"
 	"github.com/gorilla/mux"
 	ariescrypto "github.com/hyperledger/aries-framework-go/pkg/crypto"
 	"github.com/hyperledger/aries-framework-go/pkg/doc/verifiable"
@@ -290,6 +291,11 @@ func (o *Operation) deriveCredentialsHandler(rw http.ResponseWriter, req *http.R
 			fmt.Sprintf("failed to parse credential: %s", err.Error()))
 
 		return
+	}
+
+	// generates a random nonce if not provided
+	if deriveReq.Opts.Nonce == "" {
+		deriveReq.Opts.Nonce = uuid.New().String()
 	}
 
 	derived, err := credential.GenerateBBSSelectiveDisclosure(deriveReq.Frame, []byte(deriveReq.Opts.Nonce),

--- a/pkg/restapi/holder/operation/operations_test.go
+++ b/pkg/restapi/holder/operation/operations_test.go
@@ -383,7 +383,7 @@ func TestDeriveCredentials(t *testing.T) {
 		require.NotEmpty(t, derived)
 		require.Len(t, derived.Proofs, 1)
 		require.Equal(t, derived.Proofs[0]["type"], "BbsBlsSignatureProof2020")
-		require.Empty(t, derived.Proofs[0]["nonce"])
+		require.NotEmpty(t, derived.Proofs[0]["nonce"])
 		require.NotEmpty(t, derived.Proofs[0]["proofValue"])
 	})
 


### PR DESCRIPTION
Signed-off-by: Firas Qutishat <firas.qutishat@securekey.com>