### PR TITLE
feat: handle nonce cases

### DIFF
--- a/pkg/restapi/holder/operation/models.go
+++ b/pkg/restapi/holder/operation/models.go
@@ -50,7 +50,7 @@ type DeriveCredentialRequest struct {
 	Credential json.RawMessage `json:"verifiableCredential,omitempty"`
 	// Frame is JSON-LD frame used for selective disclosure.
 	Frame map[string]interface{}  `json:"frame,omitempty"`
-	Opts  DeriveCredentialOptions `json:"options,omitempty"`
+	Opts  DeriveCredentialOptions `json:"options"`
 }
 
 // DeriveCredentialResponse is model for derive credential response.
@@ -61,5 +61,5 @@ type DeriveCredentialResponse struct {
 // DeriveCredentialOptions options for derive credential.
 type DeriveCredentialOptions struct {
 	// Nonce to prove uniqueness or freshness of the proof.
-	Nonce string `json:"nonce,omitempty"`
+	Nonce *string `json:"nonce"`
 }

--- a/pkg/restapi/holder/operation/operations.go
+++ b/pkg/restapi/holder/operation/operations.go
@@ -14,6 +14,7 @@ import (
 	"net/http"
 	"time"
 
+	"github.com/google/uuid"
 	"github.com/gorilla/mux"
 	ariescrypto "github.com/hyperledger/aries-framework-go/pkg/crypto"
 	"github.com/hyperledger/aries-framework-go/pkg/doc/verifiable"
@@ -292,7 +293,13 @@ func (o *Operation) deriveCredentialsHandler(rw http.ResponseWriter, req *http.R
 		return
 	}
 
-	derived, err := credential.GenerateBBSSelectiveDisclosure(deriveReq.Frame, []byte(deriveReq.Opts.Nonce),
+	// if nonce not provided generate one
+	if deriveReq.Opts.Nonce == nil {
+		nonce := uuid.New().String()
+		deriveReq.Opts.Nonce = &nonce
+	}
+
+	derived, err := credential.GenerateBBSSelectiveDisclosure(deriveReq.Frame, []byte(*deriveReq.Opts.Nonce),
 		verifiable.WithPublicKeyFetcher(verifiable.NewDIDKeyResolver(o.vdr).PublicKeyFetcher()))
 	if err != nil {
 		commhttp.WriteErrorResponse(rw, http.StatusBadRequest,


### PR DESCRIPTION
- Case 1: No option provided - generate nonce.
- Case 2: Option provided with empty string - use empty.
- Case 3: option provided with nonce - use nonce from option.

Signed-off-by: Firas Qutishat <firas.qutishat@securekey.com>